### PR TITLE
Developments for CMSSW 9 and future trainings

### DIFF
--- a/TauAnalysisTools/bin/tauIdMVATrainingAuxFunctions.h
+++ b/TauAnalysisTools/bin/tauIdMVATrainingAuxFunctions.h
@@ -109,7 +109,7 @@ TTree* preselectTree(TTree* inputTree, const std::string& outputTreeName,
 		     const std::string& preselection, const std::vector<std::string>& branchesToKeep_expressions,
 		     int applyEventPruning, const std::string& branchNamePt, const std::string& branchNameEta, const std::string& branchNameNumMatches, 
 		     int reweight_or_KILL, bool applyPtReweighting, bool applyEtaReweighting, TH1* histogramLogPt, TH1* histogramAbsEta, TH2* histogramLogPtVsAbsEta,
-		     int maxEvents, bool checkForNaNs, unsigned reportEvery, bool applyPtDependentPruning=true)
+		     int maxEvents, bool checkForNaNs, unsigned reportEvery, bool applyPtDependentPruning=false)
 {
   std::cout << "<preselectTree>:" << std::endl;
 

--- a/TauAnalysisTools/bin/trainTauIdMVA.cc
+++ b/TauAnalysisTools/bin/trainTauIdMVA.cc
@@ -265,7 +265,7 @@ int main(int argc, char* argv[])
       reader->AddSpectator(spectatorVariableName.data(), &dummyVariable);
     }
   }
-  TMVA::IMethod* mva = reader->BookMVA(mvaMethodName.data(), Form("weights/%s_%s.weights.xml", mvaName.data(), mvaMethodName.data()));
+  TMVA::IMethod* mva = reader->BookMVA(mvaMethodName.data(), Form("dataset/weights/%s_%s.weights.xml", mvaName.data(), mvaMethodName.data()));
   saveAsGBRForest(mva, mvaName, outputFileName);
   delete mva;
   

--- a/TauAnalysisTools/plugins/BuildFile.xml
+++ b/TauAnalysisTools/plugins/BuildFile.xml
@@ -10,7 +10,6 @@
 <use name="FWCore/ServiceRegistry"/>
 <use name="CommonTools/UtilAlgos"/>
 <use name="PhysicsTools/UtilAlgos"/>
-<use name="boost"/>
 <use name="FWCore/Utilities"/>
 <use name="RecoVertex/KalmanVertexFit"/>
 <use name="TrackingTools/Records"/>

--- a/TauAnalysisTools/plugins/TauIdMVATrainingNtupleProducerMiniAOD.cc
+++ b/TauAnalysisTools/plugins/TauIdMVATrainingNtupleProducerMiniAOD.cc
@@ -462,17 +462,23 @@ void TauIdMVATrainingNtupleProducerMiniAOD::setRecTauValues(const pat::TauRef& r
 		setValueF("recDecayDistSign2D", recDecayDistSign2D_);*/
 		setValueF("recDecayDist2D", -999.);
 		setValueF("recDecayDistSign2D", -999.);
-		// calculate difference between maximally allowed Gottfried-Jackson angle (angle between tau and a1 momentum)
-		// and measured Gottfried-Jackson angle from flightlength vector and tau momentum
-		// thetaGJmax = arcsin( ( m_tau^2 - m_a1^2 ) / ( 2 * m_tau * mag(p_a1) ) )
-		// thetaGJmeasured is simply the angle between the flightLength vector and the tau momentum
-		double mTau = 1.77682;
-		double mAOne = recTau->p4().M();
-		double flightLengthMag = recTau->flightLength().Mag2();
-		double pAOneMag = recTau->p();
-		double thetaGJmax = TMath::ASin( (TMath::Power(mTau,2) - TMath::Power(mAOne,2) ) / ( 2 * mTau * pAOneMag ) );
-		double thetaGJmeasured = TMath::ACos( ( recTau->p4().px() * recTau->flightLength().x() + recTau->p4().py() * recTau->flightLength().y() + recTau->p4().pz() * recTau->flightLength().z() ) / ( pAOneMag * TMath::Sqrt(flightLengthMag) ) );
-		setValueF("recTauGJangleDiff", thetaGJmeasured - thetaGJmax);
+		// 3-prong+pi0 does not originate from a1 decay!
+		if(recTau->decayMode() == 10){
+			// calculate difference between maximally allowed Gottfried-Jackson angle (angle between tau and a1 momentum)
+			// and measured Gottfried-Jackson angle from flightlength vector and tau momentum
+			// thetaGJmax = arcsin( ( m_tau^2 - m_a1^2 ) / ( 2 * m_tau * mag(p_a1) ) )
+			// thetaGJmeasured is simply the angle between the flightLength vector and the tau momentum
+			double mTau = 1.77682;
+			double mAOne = recTau->p4().M();
+			double flightLengthMag = recTau->flightLength().Mag2();
+			double pAOneMag = recTau->p();
+			double thetaGJmax = TMath::ASin( (TMath::Power(mTau,2) - TMath::Power(mAOne,2) ) / ( 2 * mTau * pAOneMag ) );
+			double thetaGJmeasured = TMath::ACos( ( recTau->p4().px() * recTau->flightLength().x() + recTau->p4().py() * recTau->flightLength().y() + recTau->p4().pz() * recTau->flightLength().z() ) / ( pAOneMag * TMath::Sqrt(flightLengthMag) ) );
+			setValueF("recTauGJangleDiff", thetaGJmeasured - thetaGJmax);
+		}
+		else{
+			setValueF("recTauGJangleDiff", -999.);
+		}
 	}
 	else{
 		setValueF("recDecayDist2D", -999.);

--- a/TauAnalysisTools/plugins/TauIdMVATrainingNtupleProducerMiniAOD.cc
+++ b/TauAnalysisTools/plugins/TauIdMVATrainingNtupleProducerMiniAOD.cc
@@ -257,6 +257,7 @@ void TauIdMVATrainingNtupleProducerMiniAOD::beginJob()
 	addBranchI("recTauNphotonSignal");
 	addBranchI("recTauNphotonIso");
 	addBranchI("recTauNphotonTotal");
+	addBranchF("recTauGJangleMeasured");
 	addBranchF("recTauGJangleDiff");
 	addBranchF("numPileUp");
 	addBranch_EnPxPyPz("genTau");
@@ -474,15 +475,18 @@ void TauIdMVATrainingNtupleProducerMiniAOD::setRecTauValues(const pat::TauRef& r
 			double pAOneMag = recTau->p();
 			double thetaGJmax = TMath::ASin( (TMath::Power(mTau,2) - TMath::Power(mAOne,2) ) / ( 2 * mTau * pAOneMag ) );
 			double thetaGJmeasured = TMath::ACos( ( recTau->p4().px() * recTau->flightLength().x() + recTau->p4().py() * recTau->flightLength().y() + recTau->p4().pz() * recTau->flightLength().z() ) / ( pAOneMag * TMath::Sqrt(flightLengthMag) ) );
+			setValueF("recTauGJangleMeasured", thetaGJmeasured);
 			setValueF("recTauGJangleDiff", thetaGJmeasured - thetaGJmax);
 		}
 		else{
+			setValueF("recTauGJangleMeasured", -999.);
 			setValueF("recTauGJangleDiff", -999.);
 		}
 	}
 	else{
 		setValueF("recDecayDist2D", -999.);
 		setValueF("recDecayDistSign2D", -999.);
+		setValueF("recTauGJangleMeasured", -999.);
 		setValueF("recTauGJangleDiff", -999.);
 	}
 

--- a/TauAnalysisTools/plugins/TauIdMVATrainingNtupleProducerMiniAOD.h
+++ b/TauAnalysisTools/plugins/TauIdMVATrainingNtupleProducerMiniAOD.h
@@ -178,6 +178,8 @@ private:
 
 	edm::EDGetTokenT<GenEventInfoProduct> tokenGenInfoProduct_;
 
+	std::vector<std::string> ptMin_nPhotons_;
+
 	struct branchEntryType
 	{
 		branchEntryType()

--- a/TauAnalysisTools/test/copyNtuplesToNFS.py
+++ b/TauAnalysisTools/test/copyNtuplesToNFS.py
@@ -4,60 +4,60 @@ import os
 import subprocess
 
 # generic path to dCache where ntuples are stored
-inputPath = "/pnfs/desy.de/cms/tier2/store/user/anehrkor/TauIDMVATraining2016/Summer16_25ns_V2/"
+inputPath = "/pnfs/desy.de/cms/tier2/store/user/anehrkor/TauIDMVATraining2017/PhaseIFall16_81X_upgrade2017_realistic/"
 
 # generic path to NFS where we want to copy ntuples to
-outputPath = "/nfs/dust/cms/user/anehrkor/TauIDMVATraining2016/Summer16_25ns_V2/ntuples/"
+outputPath = "/nfs/dust/cms/user/anehrkor/TauIDMVATraining2017/PhaseIFall16_81X_upgrade2017_realistic_v1/ntuples/"
 
 # more or less a copy of the samples in submitTauIdMVATrainingNtupleProduction_crab3.py
 # with reduced information
 
 samples = {
-    'ZplusJets_mcatnlo' : {
-        'datasetpath'                        : 'DYJetsToLL_M-50_TuneCUETP8M1_13TeV-amcatnloFXFX-pythia8'
+    'ZplusJets_madgraph' : {
+        'datasetpath'                        : 'DYJetsToLL_M-50_TuneCUETP8M1_13TeV-madgraphMLM-pythia8'
     },
     'TT_powheg': {
         'datasetpath'                        : 'TT_TuneCUETP8M2T4_13TeV-powheg-pythia8'
     },
-    'PPmuXptGt20Mu15' : {
-        'datasetpath'                        : 'QCD_Pt-20toInf_MuEnrichedPt15_TuneCUETP8M1_13TeV_pythia8'
+#    'PPmuXptGt20Mu15' : {
+#        'datasetpath'                        : 'QCD_Pt-20toInf_MuEnrichedPt15_TuneCUETP8M1_13TeV_pythia8'
+#    },
+#    'QCDmuEnrichedPt30to50' : {
+#        'datasetpath'                        : 'QCD_Pt-30to50_MuEnrichedPt5_TuneCUETP8M1_13TeV_pythia8'
+#    },
+#    'QCDmuEnrichedPt50to80' : {
+#        'datasetpath'                        : 'QCD_Pt-50to80_MuEnrichedPt5_TuneCUETP8M1_13TeV_pythia8'
+#    },
+#    'QCDmuEnrichedPt80to120' : {
+#        'datasetpath'                        : 'QCD_Pt-80to120_MuEnrichedPt5_TuneCUETP8M1_13TeV_pythia8'
+#    },
+#    'QCDmuEnrichedPt120to170' : {
+#        'datasetpath'                        : 'QCD_Pt-120to170_MuEnrichedPt5_TuneCUETP8M1_13TeV_pythia8'
+#    },    
+#    'QCDmuEnrichedPt170to300' : {
+#        'datasetpath'                        : 'QCD_Pt-170to300_MuEnrichedPt5_TuneCUETP8M1_13TeV_pythia8'
+#    },
+#    'QCDmuEnrichedPt300to470' : {
+#        'datasetpath'                        : 'QCD_Pt-300to470_MuEnrichedPt5_TuneCUETP8M1_13TeV_pythia8'
+#    },
+#    'QCDmuEnrichedPt470to600' : {
+#        'datasetpath'                        : 'QCD_Pt-470to600_MuEnrichedPt5_TuneCUETP8M1_13TeV_pythia8'
+#    },
+#    'QCDmuEnrichedPt600to800' : {
+#        'datasetpath'                        : 'QCD_Pt-600to800_MuEnrichedPt5_TuneCUETP8M1_13TeV_pythia8'
+#    },
+#    'QCDmuEnrichedPt800to1000' : {
+#        'datasetpath'                        : 'QCD_Pt-800to1000_MuEnrichedPt5_TuneCUETP8M1_13TeV_pythia8'
+#    },
+#    'QCDmuEnrichedPtGt1000' : {
+#        'datasetpath'                        : 'QCD_Pt-1000toInf_MuEnrichedPt5_TuneCUETP8M1_13TeV_pythia8'
+#    },
+    'WplusJets_madgraph' : {
+        'datasetpath'                        : 'WJetsToLNu_TuneCUETP8M1_13TeV-madgraphMLM-pythia8'
     },
-    'QCDmuEnrichedPt30to50' : {
-        'datasetpath'                        : 'QCD_Pt-30to50_MuEnrichedPt5_TuneCUETP8M1_13TeV_pythia8'
-    },
-    'QCDmuEnrichedPt50to80' : {
-        'datasetpath'                        : 'QCD_Pt-50to80_MuEnrichedPt5_TuneCUETP8M1_13TeV_pythia8'
-    },
-    'QCDmuEnrichedPt80to120' : {
-        'datasetpath'                        : 'QCD_Pt-80to120_MuEnrichedPt5_TuneCUETP8M1_13TeV_pythia8'
-    },
-    'QCDmuEnrichedPt120to170' : {
-        'datasetpath'                        : 'QCD_Pt-120to170_MuEnrichedPt5_TuneCUETP8M1_13TeV_pythia8'
-    },    
-    'QCDmuEnrichedPt170to300' : {
-        'datasetpath'                        : 'QCD_Pt-170to300_MuEnrichedPt5_TuneCUETP8M1_13TeV_pythia8'
-    },
-    'QCDmuEnrichedPt300to470' : {
-        'datasetpath'                        : 'QCD_Pt-300to470_MuEnrichedPt5_TuneCUETP8M1_13TeV_pythia8'
-    },
-    'QCDmuEnrichedPt470to600' : {
-        'datasetpath'                        : 'QCD_Pt-470to600_MuEnrichedPt5_TuneCUETP8M1_13TeV_pythia8'
-    },
-    'QCDmuEnrichedPt600to800' : {
-        'datasetpath'                        : 'QCD_Pt-600to800_MuEnrichedPt5_TuneCUETP8M1_13TeV_pythia8'
-    },
-    'QCDmuEnrichedPt800to1000' : {
-        'datasetpath'                        : 'QCD_Pt-800to1000_MuEnrichedPt5_TuneCUETP8M1_13TeV_pythia8'
-    },
-    'QCDmuEnrichedPtGt1000' : {
-        'datasetpath'                        : 'QCD_Pt-1000toInf_MuEnrichedPt5_TuneCUETP8M1_13TeV_pythia8'
-    },
-    'WplusJets_mcatnlo' : {
-        'datasetpath'                        : 'WJetsToLNu_TuneCUETP8M1_13TeV-amcatnloFXFX-pythia8'
-    },
-    'QCDjetsFlatPt15to7000' : {
-        'datasetpath'                        : 'QCD_Pt-15to7000_TuneCUETP8M1_FlatP6_13TeV_pythia8'
-    },
+#    'QCDjetsFlatPt15to7000' : {
+#        'datasetpath'                        : 'QCD_Pt-15to7000_TuneCUETP8M1_FlatP6_13TeV_pythia8'
+#    },
     'QCDjetsPt30to50' : {
         'datasetpath'                        : 'QCD_Pt_30to50_TuneCUETP8M1_13TeV_pythia8'
     },
@@ -91,81 +91,81 @@ samples = {
     'QCDjetsPt1400to1800' : {
         'datasetpath'                        : 'QCD_Pt_1400to1800_TuneCUETP8M1_13TeV_pythia8'
     },
-    'QCDjetsPt1800to2400' : {
-        'datasetpath'                        : 'QCD_Pt_1800to2400_TuneCUETP8M1_13TeV_pythia8'
-    },
+#    'QCDjetsPt1800to2400' : {
+#        'datasetpath'                        : 'QCD_Pt_1800to2400_TuneCUETP8M1_13TeV_pythia8'
+#    },
     'QCDjetsPt2400to3200' : {
         'datasetpath'                        : 'QCD_Pt_2400to3200_TuneCUETP8M1_13TeV_pythia8'
     },
     'QCDjetsPtGt3200' : {
         'datasetpath'                        : 'QCD_Pt_3200toInf_TuneCUETP8M1_13TeV_pythia8'
     },
-    'QCDEmEnrichedPt20to30' : {
-        'datasetpath'                        : 'QCD_Pt-20to30_EMEnriched_TuneCUETP8M1_13TeV_pythia8'
-    },
-    'QCDEmEnrichedPt30to50' : {
-        'datasetpath'                        : 'QCD_Pt-30to50_EMEnriched_TuneCUETP8M1_13TeV_pythia8'
-    },
-    'QCDEmEnrichedPt50to80' : {
-        'datasetpath'                        : 'QCD_Pt-50to80_EMEnriched_TuneCUETP8M1_13TeV_pythia8'
-    },
-    'QCDEmEnrichedPt80to120' : {
-        'datasetpath'                        : 'QCD_Pt-80to120_EMEnriched_TuneCUETP8M1_13TeV_pythia8'
-    },
-    #'QCDEmEnrichedPt120to170' : {
-    #    'datasetpath'                        : 'QCD_Pt-120to170_EMEnriched_TuneCUETP8M1_13TeV_pythia8'
-    #},
-    'QCDEmEnrichedPt170to300' : {
-        'datasetpath'                        : 'QCD_Pt-170to300_EMEnriched_TuneCUETP8M1_13TeV_pythia8'
-    },
-    'QCDEmEnrichedPtGt300' : {
-        'datasetpath'                        : 'QCD_Pt-300toInf_EMEnriched_TuneCUETP8M1_13TeV_pythia8'
-    },
+#    'QCDEmEnrichedPt20to30' : {
+#        'datasetpath'                        : 'QCD_Pt-20to30_EMEnriched_TuneCUETP8M1_13TeV_pythia8'
+#    },
+#    'QCDEmEnrichedPt30to50' : {
+#        'datasetpath'                        : 'QCD_Pt-30to50_EMEnriched_TuneCUETP8M1_13TeV_pythia8'
+#    },
+#    'QCDEmEnrichedPt50to80' : {
+#        'datasetpath'                        : 'QCD_Pt-50to80_EMEnriched_TuneCUETP8M1_13TeV_pythia8'
+#    },
+#    'QCDEmEnrichedPt80to120' : {
+#        'datasetpath'                        : 'QCD_Pt-80to120_EMEnriched_TuneCUETP8M1_13TeV_pythia8'
+#    },
+#    #'QCDEmEnrichedPt120to170' : {
+#    #    'datasetpath'                        : 'QCD_Pt-120to170_EMEnriched_TuneCUETP8M1_13TeV_pythia8'
+#    #},
+#    'QCDEmEnrichedPt170to300' : {
+#        'datasetpath'                        : 'QCD_Pt-170to300_EMEnriched_TuneCUETP8M1_13TeV_pythia8'
+#    },
+#    'QCDEmEnrichedPtGt300' : {
+#        'datasetpath'                        : 'QCD_Pt-300toInf_EMEnriched_TuneCUETP8M1_13TeV_pythia8'
+#    },
 
 
 }
-smHiggsMassPoints = [ 120, 125, 130 ]
-for massPoint in smHiggsMassPoints:
-    #ggSampleName = "ggHiggs%1.0ftoTauTau" % massPoint
-    #samples[ggSampleName] = {
-    #    'datasetpath'                        : 'GluGluHToTauTau_M%1.0f_13TeV_powheg_pythia8' % massPoint
-    #}
-    #vbfSampleName = "vbfHiggs%1.0ftoTauTau" % massPoint
-    #samples[vbfSampleName] = {
-    #    'datasetpath'                        : 'VBFHToTauTau_M%1.0f_13TeV_powheg_pythia8' % massPoint
-    #}
-    #tthSampleName = "tthHiggs%1.0ftoTauTau" % massPoint
-    #samples[tthSampleName] = {
-    #    'datasetpath'                        : 'ttHJetToTT_M%1.0f_13TeV_amcatnloFXFX_madspin_pythia8' % massPoint
-    #}
-    wPlusHSampleName = "WplusHHiggs%1.0ftoTauTau" % massPoint
-    samples[wPlusHSampleName] = {
-        'datasetpath'                        : 'WplusHToTauTau_M%1.0f_13TeV_powheg_pythia8' % massPoint
-    }
-    wMinusHSampleName = "WminusHHiggs%1.0ftoTauTau" % massPoint
-    samples[wMinusHSampleName] = {
-        'datasetpath'                        : 'WminusHToTauTau_M%1.0f_13TeV_powheg_pythia8' % massPoint
-    }
-    zHSampleName = "ZHHiggs%1.0ftoTauTau" % massPoint
-    samples[zHSampleName] = {
-        'datasetpath'                        : 'ZHToTauTau_M%1.0f_13TeV_powheg_pythia8' % massPoint
-    }
-smHiggsMassPoints5 = [ 120, 130 ]
-for massPoint in smHiggsMassPoints5:
-    tthSampleName = "tthHiggs%1.0ftoTauTau" % massPoint
-    samples[tthSampleName] = {
-        'datasetpath'                        : 'ttHJetToTT_M%1.0f_13TeV_amcatnloFXFX_madspin_pythia8' % massPoint
-    }
-ggSampleName = "ggHiggs125toTauTau"
-samples[ggSampleName] = {
-    'datasetpath'                        : 'GluGluHToTauTau_M125_13TeV_powheg_pythia8'
-}
-vbfSampleName = "vbfHiggs125toTauTau"
-samples[vbfSampleName] = {
-    'datasetpath'                        : 'VBFHToTauTau_M125_13TeV_powheg_pythia8'
-}
+#smHiggsMassPoints = [ 120, 125, 130 ]
+#for massPoint in smHiggsMassPoints:
+#    #ggSampleName = "ggHiggs%1.0ftoTauTau" % massPoint
+#    #samples[ggSampleName] = {
+#    #    'datasetpath'                        : 'GluGluHToTauTau_M%1.0f_13TeV_powheg_pythia8' % massPoint
+#    #}
+#    #vbfSampleName = "vbfHiggs%1.0ftoTauTau" % massPoint
+#    #samples[vbfSampleName] = {
+#    #    'datasetpath'                        : 'VBFHToTauTau_M%1.0f_13TeV_powheg_pythia8' % massPoint
+#    #}
+#    #tthSampleName = "tthHiggs%1.0ftoTauTau" % massPoint
+#    #samples[tthSampleName] = {
+#    #    'datasetpath'                        : 'ttHJetToTT_M%1.0f_13TeV_amcatnloFXFX_madspin_pythia8' % massPoint
+#    #}
+#    wPlusHSampleName = "WplusHHiggs%1.0ftoTauTau" % massPoint
+#    samples[wPlusHSampleName] = {
+#        'datasetpath'                        : 'WplusHToTauTau_M%1.0f_13TeV_powheg_pythia8' % massPoint
+#    }
+#    wMinusHSampleName = "WminusHHiggs%1.0ftoTauTau" % massPoint
+#    samples[wMinusHSampleName] = {
+#        'datasetpath'                        : 'WminusHToTauTau_M%1.0f_13TeV_powheg_pythia8' % massPoint
+#    }
+#    zHSampleName = "ZHHiggs%1.0ftoTauTau" % massPoint
+#    samples[zHSampleName] = {
+#        'datasetpath'                        : 'ZHToTauTau_M%1.0f_13TeV_powheg_pythia8' % massPoint
+#    }
+#smHiggsMassPoints5 = [ 120, 130 ]
+#for massPoint in smHiggsMassPoints5:
+#    tthSampleName = "tthHiggs%1.0ftoTauTau" % massPoint
+#    samples[tthSampleName] = {
+#        'datasetpath'                        : 'ttHJetToTT_M%1.0f_13TeV_amcatnloFXFX_madspin_pythia8' % massPoint
+#    }
+#ggSampleName = "ggHiggs125toTauTau"
+#samples[ggSampleName] = {
+#    'datasetpath'                        : 'GluGluHToTauTau_M125_13TeV_powheg_pythia8'
+#}
+#vbfSampleName = "vbfHiggs125toTauTau"
+#samples[vbfSampleName] = {
+#    'datasetpath'                        : 'VBFHToTauTau_M125_13TeV_powheg_pythia8'
+#}
 # currently 29 mass points available
-mssmHiggsMassPoints1 = [ 80, 90, 100, 110, 120, 130, 160, 180, 200, 250, 300, 350, 400, 450, 500, 600, 700, 800, 1000, 1200, 1400, 1500, 1600, 1800, 2000, 2300, 2600, 2900, 3200 ]
+mssmHiggsMassPoints1 = [ 140, 160, 180, 200, 250, 300, 350, 400, 450, 500, 600, 700, 800, 900, 1000, 1200, 1400, 1600, 1800, 2000, 2300, 2600, 2900 ]
 for massPoint in mssmHiggsMassPoints1:
     ggSampleName = "ggA%1.0ftoTauTau" % massPoint
     samples[ggSampleName] = {
@@ -173,7 +173,7 @@ for massPoint in mssmHiggsMassPoints1:
     }
 
 # currently 31 mass points available
-mssmHiggsMassPoints2 = [ 80, 90, 100, 110, 120, 130, 140, 160, 180, 200, 250, 300, 350, 400, 450, 500, 600, 700, 800, 900, 1000, 1200, 1400, 1500, 1600, 1800, 2000, 2300, 2600, 2900, 3200 ]
+mssmHiggsMassPoints2 = [ 140, 160, 180, 200, 250, 300, 350, 400, 450, 500, 600, 700, 800, 900, 1000, 1200, 1400, 1600, 1800, 2000, 2300, 2600, 3200 ]
 for massPoint in mssmHiggsMassPoints2:
     bbSampleName = "bbA%1.0ftoTauTau" % massPoint
     samples[bbSampleName] = {
@@ -181,20 +181,20 @@ for massPoint in mssmHiggsMassPoints2:
     }
 
 # currently 11 mass points available
-ZprimeMassPoints = [ 500, 750, 1000, 1250, 1500, 1750, 2000, 2500, 3000, 3500, 4000 ]
+ZprimeMassPoints = [ 750, 1000, 1250, 1750, 2000, 2500, 3000, 3500, 4000 ]
 for massPoint in ZprimeMassPoints:
     sampleName = "Zprime%1.0ftoTauTau" % massPoint
     samples[sampleName] = {
         'datasetpath'                        : 'ZprimeToTauTau_M-%1.0f_TuneCUETP8M1_13TeV-pythia8-tauola' % massPoint
     }
 
-# currently 27 mass points available
-WprimeMassPoints = [ 400, 600, 1000, 1200, 1400, 1600, 1800, 2000, 2200, 2400, 2600, 2800, 3000, 3200, 3400, 3600, 3800, 4000, 4200, 4400, 4600, 4800, 5000, 5200, 5400, 5600, 5800 ]
-for massPoint in WprimeMassPoints:
-    sampleName = "Wprime%1.0ftoTauNu" % massPoint
-    samples[sampleName] = {
-        'datasetpath'                        : 'WprimeToTauNu_M-%1.0f_TuneCUETP8M1_13TeV-pythia8-tauola' % massPoint
-    }
+## currently 27 mass points available
+#WprimeMassPoints = [ 400, 600, 1000, 1200, 1400, 1600, 1800, 2000, 2200, 2400, 2600, 2800, 3000, 3200, 3400, 3600, 3800, 4000, 4200, 4400, 4600, 4800, 5000, 5200, 5400, 5600, 5800 ]
+#for massPoint in WprimeMassPoints:
+#    sampleName = "Wprime%1.0ftoTauNu" % massPoint
+#    samples[sampleName] = {
+#        'datasetpath'                        : 'WprimeToTauNu_M-%1.0f_TuneCUETP8M1_13TeV-pythia8-tauola' % massPoint
+#    }
 
 # loop through dictionary, create directories according to sampleName
 # and copy corresponding ntuples to the directory

--- a/TauAnalysisTools/test/produceTauIdMVATrainingNtupleMiniAOD_cfg.py
+++ b/TauAnalysisTools/test/produceTauIdMVATrainingNtupleMiniAOD_cfg.py
@@ -14,7 +14,7 @@ process.load('Configuration.StandardSequences.GeometryRecoDB_cff')
 process.load('Configuration.StandardSequences.MagneticField_cff')
 process.load('Configuration/StandardSequences/FrontierConditions_GlobalTag_cff')
 from Configuration.AlCa.GlobalTag import GlobalTag
-process.GlobalTag = GlobalTag(process.GlobalTag, '80X_mcRun2_asymptotic_2016_TrancheIV_v7', '')
+process.GlobalTag = GlobalTag(process.GlobalTag, '81X_upgrade2017_realistic_v26', '')
 
 #process.add_(cms.Service("PrintLoadingPlugins"))
 
@@ -27,7 +27,7 @@ process.source = cms.Source("PoolSource",
         #'root://xrootd.ba.infn.it//store/cmst3/user/ytakahas/CMG/QCD_Pt-15to3000_Tune4C_Flat_13TeV_pythia8/Phys14DR-PU20bx25_trkalmb_PHYS14_25_V1-v1/AODSIM/Dynamic95_20150520/aod_1.root'
         #'file:/disk1/MVAonMiniAOD/RelValZTT_8_0_20_PU25ns_MINIAODSIM_1.root',
         #'file:/disk1/MVAonMiniAOD/RelValZTT_8_0_20_PU25ns_MINIAODSIM_2.root'
-        'file:/disk1/MVAonMiniAOD/DYJetsToLLM50_AMCATNLO_MORIOND17_MINIAODSIM_1.root'
+        'root://cms-xrd-global.cern.ch//store/mc/PhaseIFall16MiniAOD/DYJetsToLL_M-50_TuneCUETP8M1_13TeV-madgraphMLM-pythia8/MINIAODSIM/PhaseIFall16PUFlat20to50_PhaseIFall16_81X_upgrade2017_realistic_v26_ext1-v1/70000/02A37775-A0E9-E611-8E01-0025907B4F2E.root'
     ),
     ##eventsToProcess = cms.untracked.VEventRange(
     ##    '1:917:1719279',
@@ -70,6 +70,107 @@ if type == 'SignalMC':
 else:
     isSignal = False
 #--------------------------------------------------------------------------------
+from RecoTauTag.RecoTau.TauDiscriminatorTools import noPrediscriminants
+process.load('RecoTauTag.Configuration.loadRecoTauTagMVAsFromPrepDB_cfi')
+from RecoTauTag.RecoTau.PATTauDiscriminationByMVAIsolationRun2_cff import *
+
+process.rerunDiscriminationByIsolationOldDMMVArun2v1raw = patDiscriminationByIsolationMVArun2v1raw.clone(
+	PATTauProducer = cms.InputTag('slimmedTaus'),
+	Prediscriminants = noPrediscriminants,
+	loadMVAfromDB = cms.bool(True),
+	mvaName = cms.string("RecoTauTag_tauIdMVAIsoDBoldDMwLT2016v1"),
+	mvaOpt = cms.string("DBoldDMwLT"),
+	requireDecayMode = cms.bool(True),
+	verbosity = cms.int32(0)
+)
+
+process.rerunDiscriminationByIsolationOldDMMVArun2v1VLoose = patDiscriminationByIsolationMVArun2v1VLoose.clone(
+	PATTauProducer = cms.InputTag('slimmedTaus'),    
+	Prediscriminants = noPrediscriminants,
+	toMultiplex = cms.InputTag('rerunDiscriminationByIsolationOldDMMVArun2v1raw'),
+	key = cms.InputTag('rerunDiscriminationByIsolationOldDMMVArun2v1raw:category'),
+	loadMVAfromDB = cms.bool(True),
+	mvaOutput_normalization = cms.string("RecoTauTag_tauIdMVAIsoDBoldDMwLT2016v1_mvaOutput_normalization"),
+	mapping = cms.VPSet(
+		cms.PSet(
+			category = cms.uint32(0),
+			cut = cms.string("RecoTauTag_tauIdMVAIsoDBoldDMwLT2016v1_WPEff90"),
+			variable = cms.string("pt"),
+		)
+	)
+)
+
+process.rerunDiscriminationByIsolationOldDMMVArun2v1Loose = process.rerunDiscriminationByIsolationOldDMMVArun2v1VLoose.clone()
+process.rerunDiscriminationByIsolationOldDMMVArun2v1Loose.mapping[0].cut = cms.string("RecoTauTag_tauIdMVAIsoDBoldDMwLT2016v1_WPEff80")
+process.rerunDiscriminationByIsolationOldDMMVArun2v1Medium = process.rerunDiscriminationByIsolationOldDMMVArun2v1VLoose.clone()
+process.rerunDiscriminationByIsolationOldDMMVArun2v1Medium.mapping[0].cut = cms.string("RecoTauTag_tauIdMVAIsoDBoldDMwLT2016v1_WPEff70")
+process.rerunDiscriminationByIsolationOldDMMVArun2v1Tight = process.rerunDiscriminationByIsolationOldDMMVArun2v1VLoose.clone()
+process.rerunDiscriminationByIsolationOldDMMVArun2v1Tight.mapping[0].cut = cms.string("RecoTauTag_tauIdMVAIsoDBoldDMwLT2016v1_WPEff60")
+process.rerunDiscriminationByIsolationOldDMMVArun2v1VTight = process.rerunDiscriminationByIsolationOldDMMVArun2v1VLoose.clone()
+process.rerunDiscriminationByIsolationOldDMMVArun2v1VTight.mapping[0].cut = cms.string("RecoTauTag_tauIdMVAIsoDBoldDMwLT2016v1_WPEff50")
+process.rerunDiscriminationByIsolationOldDMMVArun2v1VVTight = process.rerunDiscriminationByIsolationOldDMMVArun2v1VLoose.clone()
+process.rerunDiscriminationByIsolationOldDMMVArun2v1VVTight.mapping[0].cut = cms.string("RecoTauTag_tauIdMVAIsoDBoldDMwLT2016v1_WPEff40")
+
+process.rerunDiscriminationByIsolationNewDMMVArun2v1raw = process.rerunDiscriminationByIsolationOldDMMVArun2v1raw.clone()
+process.rerunDiscriminationByIsolationNewDMMVArun2v1raw.mvaName = cms.string("RecoTauTag_tauIdMVAIsoDBnewDMwLT2016v1")
+process.rerunDiscriminationByIsolationNewDMMVArun2v1raw.mvaOpt = cms.string("DBnewDMwLT")
+
+process.rerunDiscriminationByIsolationNewDMMVArun2v1VLoose = process.rerunDiscriminationByIsolationOldDMMVArun2v1VLoose.clone()
+process.rerunDiscriminationByIsolationNewDMMVArun2v1VLoose.toMultiplex = cms.InputTag('rerunDiscriminationByIsolationNewDMMVArun2v1raw')
+process.rerunDiscriminationByIsolationNewDMMVArun2v1VLoose.key = cms.InputTag('rerunDiscriminationByIsolationNewDMMVArun2v1raw:category')
+process.rerunDiscriminationByIsolationNewDMMVArun2v1VLoose.mvaOutput_normalization = cms.string("RecoTauTag_tauIdMVAIsoDBnewDMwLT2016v1_mvaOutput_normalization")
+process.rerunDiscriminationByIsolationNewDMMVArun2v1VLoose.mapping[0].cut = cms.string("RecoTauTag_tauIdMVAIsoDBnewDMwLT2016v1_WPEff90")
+
+process.rerunDiscriminationByIsolationNewDMMVArun2v1Loose = process.rerunDiscriminationByIsolationNewDMMVArun2v1VLoose.clone()
+process.rerunDiscriminationByIsolationNewDMMVArun2v1Loose.mapping[0].cut = cms.string("RecoTauTag_tauIdMVAIsoDBnewDMwLT2016v1_WPEff80")
+process.rerunDiscriminationByIsolationNewDMMVArun2v1Medium = process.rerunDiscriminationByIsolationNewDMMVArun2v1VLoose.clone()
+process.rerunDiscriminationByIsolationNewDMMVArun2v1Medium.mapping[0].cut = cms.string("RecoTauTag_tauIdMVAIsoDBnewDMwLT2016v1_WPEff70")
+process.rerunDiscriminationByIsolationNewDMMVArun2v1Tight = process.rerunDiscriminationByIsolationNewDMMVArun2v1VLoose.clone()
+process.rerunDiscriminationByIsolationNewDMMVArun2v1Tight.mapping[0].cut = cms.string("RecoTauTag_tauIdMVAIsoDBnewDMwLT2016v1_WPEff60")
+process.rerunDiscriminationByIsolationNewDMMVArun2v1VTight = process.rerunDiscriminationByIsolationNewDMMVArun2v1VLoose.clone()
+process.rerunDiscriminationByIsolationNewDMMVArun2v1VTight.mapping[0].cut = cms.string("RecoTauTag_tauIdMVAIsoDBnewDMwLT2016v1_WPEff50")
+process.rerunDiscriminationByIsolationNewDMMVArun2v1VVTight = process.rerunDiscriminationByIsolationNewDMMVArun2v1VLoose.clone()
+process.rerunDiscriminationByIsolationNewDMMVArun2v1VVTight.mapping[0].cut = cms.string("RecoTauTag_tauIdMVAIsoDBnewDMwLT2016v1_WPEff40")
+
+process.rerunMvaIsolationSequence = cms.Sequence(
+	process.rerunDiscriminationByIsolationOldDMMVArun2v1raw
+	*process.rerunDiscriminationByIsolationOldDMMVArun2v1VLoose
+	*process.rerunDiscriminationByIsolationOldDMMVArun2v1Loose
+	*process.rerunDiscriminationByIsolationOldDMMVArun2v1Medium
+	*process.rerunDiscriminationByIsolationOldDMMVArun2v1Tight
+	*process.rerunDiscriminationByIsolationOldDMMVArun2v1VTight
+	*process.rerunDiscriminationByIsolationOldDMMVArun2v1VVTight
+	*process.rerunDiscriminationByIsolationNewDMMVArun2v1raw
+	*process.rerunDiscriminationByIsolationNewDMMVArun2v1VLoose
+	*process.rerunDiscriminationByIsolationNewDMMVArun2v1Loose
+	*process.rerunDiscriminationByIsolationNewDMMVArun2v1Medium
+	*process.rerunDiscriminationByIsolationNewDMMVArun2v1Tight
+	*process.rerunDiscriminationByIsolationNewDMMVArun2v1VTight
+	*process.rerunDiscriminationByIsolationNewDMMVArun2v1VVTight
+)
+
+embedID = cms.EDProducer("PATTauIDEmbedder",
+	src = cms.InputTag('slimmedTaus'),
+	tauIDSources = cms.PSet(
+		byIsolationMVArun2v1DBoldDMwLTraw2016 = cms.InputTag('rerunDiscriminationByIsolationOldDMMVArun2v1raw'),
+		byVLooseIsolationMVArun2v1DBoldDMwLT2016 = cms.InputTag('rerunDiscriminationByIsolationOldDMMVArun2v1VLoose'),
+		byLooseIsolationMVArun2v1DBoldDMwLT2016 = cms.InputTag('rerunDiscriminationByIsolationOldDMMVArun2v1Loose'),
+		byMediumIsolationMVArun2v1DBoldDMwLT2016 = cms.InputTag('rerunDiscriminationByIsolationOldDMMVArun2v1Medium'),
+		byTightIsolationMVArun2v1DBoldDMwLT2016 = cms.InputTag('rerunDiscriminationByIsolationOldDMMVArun2v1Tight'),
+		byVTightIsolationMVArun2v1DBoldDMwLT2016 = cms.InputTag('rerunDiscriminationByIsolationOldDMMVArun2v1VTight'),
+		byVVTightIsolationMVArun2v1DBoldDMwLT2016 = cms.InputTag('rerunDiscriminationByIsolationOldDMMVArun2v1VVTight'),
+		byIsolationMVArun2v1DBnewDMwLTraw2016 = cms.InputTag('rerunDiscriminationByIsolationNewDMMVArun2v1raw'),
+		byVLooseIsolationMVArun2v1DBnewDMwLT2016 = cms.InputTag('rerunDiscriminationByIsolationNewDMMVArun2v1VLoose'),
+		byLooseIsolationMVArun2v1DBnewDMwLT2016 = cms.InputTag('rerunDiscriminationByIsolationNewDMMVArun2v1Loose'),
+		byMediumIsolationMVArun2v1DBnewDMwLT2016 = cms.InputTag('rerunDiscriminationByIsolationNewDMMVArun2v1Medium'),
+		byTightIsolationMVArun2v1DBnewDMwLT2016 = cms.InputTag('rerunDiscriminationByIsolationNewDMMVArun2v1Tight'),
+		byVTightIsolationMVArun2v1DBnewDMwLT2016 = cms.InputTag('rerunDiscriminationByIsolationNewDMMVArun2v1VTight'),
+		byVVTightIsolationMVArun2v1DBnewDMwLT2016 = cms.InputTag('rerunDiscriminationByIsolationNewDMMVArun2v1VVTight')
+	),
+)
+setattr(process, "NewTauIDsEmbedded", embedID)
+
+#--------------------------------------------------------------------------------
    
 process.produceTauIdMVATrainingNtupleMiniAODSequence = cms.Sequence()
 
@@ -109,7 +210,7 @@ srcWeights = []
 #--------------------------------------------------------------------------------
 
 process.tauIdMVATrainingNtupleProducerMiniAOD = cms.EDProducer("TauIdMVATrainingNtupleProducerMiniAOD",
-    srcRecTaus = cms.InputTag('slimmedTaus'),
+    srcRecTaus = cms.InputTag('NewTauIDsEmbedded'),
     srcPrunedGenParticles = cms.InputTag('prunedGenParticles'),
     srcPackedGenParticles = cms.InputTag('packedGenParticles'),        
     minGenVisPt = cms.double(10.),                                          
@@ -142,6 +243,20 @@ process.tauIdMVATrainingNtupleProducerMiniAOD = cms.EDProducer("TauIdMVATraining
         byTightIsolationMVArun2v1DBdR03oldDMwLT = cms.string("byTightIsolationMVArun2v1DBdR03oldDMwLT"),
         byVTightIsolationMVArun2v1DBdR03oldDMwLT = cms.string("byVTightIsolationMVArun2v1DBdR03oldDMwLT"),
         byVVTightIsolationMVArun2v1DBdR03oldDMwLT = cms.string("byVVTightIsolationMVArun2v1DBdR03oldDMwLT"),
+        byIsolationMVArun2v1DBoldDMwLTraw2016 = cms.string("byIsolationMVArun2v1DBoldDMwLTraw2016"),
+        byVLooseIsolationMVArun2v1DBoldDMwLT2016 = cms.string("byVLooseIsolationMVArun2v1DBoldDMwLT2016"),
+        byLooseIsolationMVArun2v1DBoldDMwLT2016 = cms.string("byLooseIsolationMVArun2v1DBoldDMwLT2016"),
+        byMediumIsolationMVArun2v1DBoldDMwLT2016 = cms.string("byMediumIsolationMVArun2v1DBoldDMwLT2016"),
+        byTightIsolationMVArun2v1DBoldDMwLT2016 = cms.string("byTightIsolationMVArun2v1DBoldDMwLT2016"),
+        byVTightIsolationMVArun2v1DBoldDMwLT2016 = cms.string("byVTightIsolationMVArun2v1DBoldDMwLT2016"),
+        byVVTightIsolationMVArun2v1DBoldDMwLT2016 = cms.string("byVVTightIsolationMVArun2v1DBoldDMwLT2016"),
+        byIsolationMVArun2v1DBnewDMwLTraw2016 = cms.string("byIsolationMVArun2v1DBnewDMwLTraw2016"),
+        byVLooseIsolationMVArun2v1DBnewDMwLT2016 = cms.string("byVLooseIsolationMVArun2v1DBnewDMwLT2016"),
+        byLooseIsolationMVArun2v1DBnewDMwLT2016 = cms.string("byLooseIsolationMVArun2v1DBnewDMwLT2016"),
+        byMediumIsolationMVArun2v1DBnewDMwLT2016 = cms.string("byMediumIsolationMVArun2v1DBnewDMwLT2016"),
+        byTightIsolationMVArun2v1DBnewDMwLT2016 = cms.string("byTightIsolationMVArun2v1DBnewDMwLT2016"),
+        byVTightIsolationMVArun2v1DBnewDMwLT2016 = cms.string("byVTightIsolationMVArun2v1DBnewDMwLT2016"),
+        byVVTightIsolationMVArun2v1DBnewDMwLT2016 = cms.string("byVVTightIsolationMVArun2v1DBnewDMwLT2016"),
         againstMuonLoose3 = cms.string('againstMuonLoose3'),
         againstMuonTight3 = cms.string('againstMuonTight3')
     ),
@@ -190,7 +305,7 @@ process.tauIdMVATrainingNtupleProducerMiniAOD = cms.EDProducer("TauIdMVATraining
 #setattr(process.tauIdMVATrainingNtupleProducerMiniAOD.isolationPtSums, psetName, pset)
 process.produceTauIdMVATrainingNtupleMiniAODSequence += process.tauIdMVATrainingNtupleProducerMiniAOD
 
-process.p = cms.Path(process.produceTauIdMVATrainingNtupleMiniAODSequence)
+process.p = cms.Path(process.rerunMvaIsolationSequence*getattr(process, "NewTauIDsEmbedded")*process.produceTauIdMVATrainingNtupleMiniAODSequence)
 #process.printEventContent = cms.EDAnalyzer("EventContentAnalyzer")
 #process.printFirstEventContentPath = cms.Path(process.printEventContent)
 #process.Schedule = cms.Schedule(process.p, process.printFirstEventContentPath)

--- a/TauAnalysisTools/test/produceTauIdMVATrainingNtupleMiniAOD_cfg.py
+++ b/TauAnalysisTools/test/produceTauIdMVATrainingNtupleMiniAOD_cfg.py
@@ -288,6 +288,7 @@ process.tauIdMVATrainingNtupleProducerMiniAOD = cms.EDProducer("TauIdMVATraining
     matchGenTauVis = cms.bool(True),
     #--------------------------------------------------------                                                                       
     srcWeights = cms.VInputTag(srcWeights),
+    ptMin_nPhotons = cms.vstring("0.5","0.75","1.0","1.25","1.5"),
     verbosity = cms.int32(0)
 )
 

--- a/TauAnalysisTools/test/runTauIdMVATraining.py
+++ b/TauAnalysisTools/test/runTauIdMVATraining.py
@@ -1329,7 +1329,7 @@ for discriminator in mvaDiscriminators.keys():
         cfg_modified += "\n"    
         cfg_modified += "delattr(process.makeROCcurveTauIdMVA, 'signalSamples')\n"
         cfg_modified += "delattr(process.makeROCcurveTauIdMVA, 'backgroundSamples')\n"
-        cfg_modified += "process.makeROCcurveTauIdMVA.treeName = cms.string('%s')\n" % tree
+        cfg_modified += "process.makeROCcurveTauIdMVA.treeName = cms.string('dataset/%s')\n" % tree
         ##cfg_modified += "process.makeROCcurveTauIdMVA.preselection = cms.string('%s')\n" % mvaDiscriminators[discriminator]['preselection']
         cfg_modified += "process.makeROCcurveTauIdMVA.preselection = cms.string('')\n"
         cfg_modified += "process.makeROCcurveTauIdMVA.classId_signal = cms.int32(0)\n"

--- a/TauAnalysisTools/test/runTauIdMVATrainingMiniAOD_deltaBeta_dR03_newDM.py
+++ b/TauAnalysisTools/test/runTauIdMVATrainingMiniAOD_deltaBeta_dR03_newDM.py
@@ -375,7 +375,7 @@ for discriminator in mvaDiscriminators.keys():
         cfg_modified += "\n"    
         cfg_modified += "delattr(process.makeROCcurveTauIdMVA, 'signalSamples')\n"
         cfg_modified += "delattr(process.makeROCcurveTauIdMVA, 'backgroundSamples')\n"
-        cfg_modified += "process.makeROCcurveTauIdMVA.treeName = cms.string('%s')\n" % tree
+        cfg_modified += "process.makeROCcurveTauIdMVA.treeName = cms.string('dataset/%s')\n" % tree
         ##cfg_modified += "process.makeROCcurveTauIdMVA.preselection = cms.string('%s')\n" % mvaDiscriminators[discriminator]['preselection']
         cfg_modified += "process.makeROCcurveTauIdMVA.preselection = cms.string('')\n"
         cfg_modified += "process.makeROCcurveTauIdMVA.classId_signal = cms.int32(0)\n"
@@ -481,7 +481,7 @@ else:
                 cfg_modified += "\n"
                 cfg_modified += "delattr(process.makeROCcurveTauIdMVA, 'signalSamples')\n"
                 cfg_modified += "delattr(process.makeROCcurveTauIdMVA, 'backgroundSamples')\n"
-                cfg_modified += "process.makeROCcurveTauIdMVA.treeName = cms.string('%s')\n" % tree
+                cfg_modified += "process.makeROCcurveTauIdMVA.treeName = cms.string('dataset/%s')\n" % tree
                 cfg_modified += "process.makeROCcurveTauIdMVA.preselection = cms.string('')\n"
                 cfg_modified += "process.makeROCcurveTauIdMVA.classId_signal = cms.int32(0)\n"
                 cfg_modified += "process.makeROCcurveTauIdMVA.classId_background = cms.int32(1)\n"

--- a/TauAnalysisTools/test/runTauIdMVATrainingMiniAOD_deltaBeta_dR03_newDM.py
+++ b/TauAnalysisTools/test/runTauIdMVATrainingMiniAOD_deltaBeta_dR03_newDM.py
@@ -70,14 +70,63 @@ mvaDiscriminators = {
         'otherVariables' : [
         ],
         'legendEntry'         : "MVA opt1bLTDBdR03",
-        'color'               : 1
+        'color'               : 2
+    },
+    'mvaIsolation3HitsDeltaR03opt2bLTDB' : {
+        'preselection'		: preselection_newDMs,
+        'applyPtReweighting'  : True,
+        'applyEtaReweighting' : True,
+        'reweight'			: 'min:KILL',
+        'applyEventPruningSignal'   : 0, # no random pruning
+        'applyEventPruningBackground' : 0, # no random pruning
+        'applyPtDependentPruningSignal' : False, # no pt-dependent pruning
+        'applyPtDependentPruningBackground' : False, # no pt-dependent pruning
+        'mvaTrainingOptions'  : "!H:!V:NTrees=1000:BoostType=Grad:Shrinkage=0.20:UseBaggedBoost:GradBaggingFraction=0.5:SeparationType=GiniIndex:nCuts=500:PruneMethod=NoPruning:MaxDepth=5",
+        'inputVariables'	  : [
+            'TMath::Log(TMath::Max(1., recTauPt))/F',
+            'TMath::Abs(recTauEta)/F',
+            'TMath::Log(TMath::Max(1.e-2, chargedIsoPtSumdR03))/F',
+            'TMath::Log(TMath::Max(1.e-2, neutralIsoPtSumdR03))/F',
+            'TMath::Log(TMath::Max(1.e-2, puCorrPtSum))/F',
+            'TMath::Log(TMath::Max(1.e-2, photonPtSumOutsideSignalConedR03))/F',
+            'recTauDecayMode/I',
+            'TMath::Min(30., recTauNphoton)/F',
+            'TMath::Min(0.5, recTauPtWeightedDetaStrip)/F',
+            'TMath::Min(0.5, recTauPtWeightedDphiStrip)/F',
+            'TMath::Min(0.5, recTauPtWeightedDrSignal)/F',
+            'TMath::Min(0.5, recTauPtWeightedDrIsolation)/F',
+            'TMath::Min(1., recTauEratio)/F',
+            'TMath::Sign(+1., recImpactParam)/F',
+            'TMath::Sqrt(TMath::Abs(TMath::Min(1., TMath::Abs(recImpactParam))))/F',
+            'TMath::Min(10., TMath::Abs(recImpactParamSign))/F',
+            'TMath::Sign(+1., recImpactParam3D)/F',
+            'TMath::Sqrt(TMath::Abs(TMath::Min(1., TMath::Abs(recImpactParam3D))))/F',
+            'TMath::Min(10., TMath::Abs(recImpactParamSign3D))/F',
+            'hasRecDecayVertex/I',
+            'TMath::Sqrt(recDecayDistMag)/F',
+            'TMath::Min(10., recDecayDistSign)/F',
+            'TMath::Max(-1.,recTauGJangleDiff)/F'
+        ],
+        'spectatorVariables'  : [
+            ##'recTauPt/F',
+            'leadPFChargedHadrCandPt/F',
+            'numOfflinePrimaryVertices/I',
+            'genVisTauPt/F',
+            'genTauPt/F',
+            'byIsolationMVArun2v1DBdR03newDMwLTraw'
+        ],
+        'otherVariables' : [
+        ],
+        'legendEntry'         : "MVA opt2bLTDBdR03",
+        'color'               : 2
     }
 }
 
 plots = {
 'mvaIsolation_optDeltaR03BDeltaBeta' : {
         'graphs' : [
-            'mvaIsolation3HitsDeltaR03opt1bLTDB'
+            'mvaIsolation3HitsDeltaR03opt1bLTDB',
+            'mvaIsolation3HitsDeltaR03opt2bLTDB'
         ]
     }
 }

--- a/TauAnalysisTools/test/runTauIdMVATrainingMiniAOD_deltaBeta_dR03_oldDM.py
+++ b/TauAnalysisTools/test/runTauIdMVATrainingMiniAOD_deltaBeta_dR03_oldDM.py
@@ -391,7 +391,7 @@ for discriminator in mvaDiscriminators.keys():
         cfg_modified += "\n"    
         cfg_modified += "delattr(process.makeROCcurveTauIdMVA, 'signalSamples')\n"
         cfg_modified += "delattr(process.makeROCcurveTauIdMVA, 'backgroundSamples')\n"
-        cfg_modified += "process.makeROCcurveTauIdMVA.treeName = cms.string('%s')\n" % tree
+        cfg_modified += "process.makeROCcurveTauIdMVA.treeName = cms.string('dataset/%s')\n" % tree
         ##cfg_modified += "process.makeROCcurveTauIdMVA.preselection = cms.string('%s')\n" % mvaDiscriminators[discriminator]['preselection']
         cfg_modified += "process.makeROCcurveTauIdMVA.preselection = cms.string('')\n"
         cfg_modified += "process.makeROCcurveTauIdMVA.classId_signal = cms.int32(0)\n"
@@ -497,7 +497,7 @@ else:
                 cfg_modified += "\n"
                 cfg_modified += "delattr(process.makeROCcurveTauIdMVA, 'signalSamples')\n"
                 cfg_modified += "delattr(process.makeROCcurveTauIdMVA, 'backgroundSamples')\n"
-                cfg_modified += "process.makeROCcurveTauIdMVA.treeName = cms.string('%s')\n" % tree
+                cfg_modified += "process.makeROCcurveTauIdMVA.treeName = cms.string('dataset/%s')\n" % tree
                 cfg_modified += "process.makeROCcurveTauIdMVA.preselection = cms.string('')\n"
                 cfg_modified += "process.makeROCcurveTauIdMVA.classId_signal = cms.int32(0)\n"
                 cfg_modified += "process.makeROCcurveTauIdMVA.classId_background = cms.int32(1)\n"

--- a/TauAnalysisTools/test/runTauIdMVATrainingMiniAOD_deltaBeta_dR03_oldDM.py
+++ b/TauAnalysisTools/test/runTauIdMVATrainingMiniAOD_deltaBeta_dR03_oldDM.py
@@ -72,6 +72,54 @@ mvaDiscriminators = {
         ],
         'legendEntry'         : "MVA opt1aLTDBdR03",
         'color'               : 1
+    },
+    'mvaIsolation3HitsDeltaR03opt2aLTDB' : {
+        'preselection'		: preselection_oldDMs,
+        'applyPtReweighting'  : True,
+        'applyEtaReweighting' : True,
+        'reweight'			: 'min:KILL',
+        'applyEventPruningSignal'   : 0, # no random pruning
+        'applyEventPruningBackground' : 0, # no random pruning
+        'applyPtDependentPruningSignal' : False, # no pt-dependent pruning
+        'applyPtDependentPruningBackground' : False, # no pt-dependent pruning
+        'mvaTrainingOptions'  : "!H:!V:NTrees=1000:BoostType=Grad:Shrinkage=0.20:UseBaggedBoost:GradBaggingFraction=0.5:SeparationType=GiniIndex:nCuts=500:PruneMethod=NoPruning:MaxDepth=5",
+        'inputVariables'	  : [
+            'TMath::Log(TMath::Max(1., recTauPt))/F',
+            'TMath::Abs(recTauEta)/F',
+            'TMath::Log(TMath::Max(1.e-2, chargedIsoPtSumdR03))/F',
+            'TMath::Log(TMath::Max(1.e-2, neutralIsoPtSumdR03))/F',
+            'TMath::Log(TMath::Max(1.e-2, puCorrPtSum))/F',
+            'TMath::Log(TMath::Max(1.e-2, photonPtSumOutsideSignalConedR03))/F',
+            'recTauDecayMode/I',
+            'TMath::Min(30., recTauNphoton)/F',
+            'TMath::Min(0.5, recTauPtWeightedDetaStrip)/F',
+            'TMath::Min(0.5, recTauPtWeightedDphiStrip)/F',
+            'TMath::Min(0.5, recTauPtWeightedDrSignal)/F',
+            'TMath::Min(0.5, recTauPtWeightedDrIsolation)/F',
+            'TMath::Min(1., recTauEratio)/F',
+            'TMath::Sign(+1., recImpactParam)/F',
+            'TMath::Sqrt(TMath::Abs(TMath::Min(1., TMath::Abs(recImpactParam))))/F',
+            'TMath::Min(10., TMath::Abs(recImpactParamSign))/F',
+            'TMath::Sign(+1., recImpactParam3D)/F',
+            'TMath::Sqrt(TMath::Abs(TMath::Min(1., TMath::Abs(recImpactParam3D))))/F',
+            'TMath::Min(10., TMath::Abs(recImpactParamSign3D))/F',
+            'hasRecDecayVertex/I',
+            'TMath::Sqrt(recDecayDistMag)/F',
+            'TMath::Min(10., recDecayDistSign)/F',
+            'TMath::Max(-1.,recTauGJangleDiff)/F'
+        ],
+        'spectatorVariables'  : [
+            ##'recTauPt/F',
+            'leadPFChargedHadrCandPt/F',
+            'numOfflinePrimaryVertices/I',
+            'genVisTauPt/F',
+            'genTauPt/F',
+            'byIsolationMVArun2v1DBdR03oldDMwLTraw'
+        ],
+        'otherVariables' : [
+        ],
+        'legendEntry'         : "MVA opt2aLTDBdR03",
+        'color'               : 2
     }
 }
 
@@ -83,7 +131,7 @@ cutDiscriminators = {
         'min'                 : -1.5,
         'max'                 : +1.5,
         'legendEntry'         : "2015 MVA",
-        'color'               : 2
+        'color'               : 3
     }
 }
 
@@ -91,6 +139,7 @@ plots = {
 'mvaIsolation_optDeltaR03BDeltaBeta' : {
         'graphs' : [
             'mvaIsolation3HitsDeltaR03opt1aLTDB',
+            'mvaIsolation3HitsDeltaR03opt2aLTDB',
             'rawMVAoldDMdR03wLT'
         ]
     }

--- a/TauAnalysisTools/test/runTauIdMVATrainingMiniAOD_deltaBeta_newDM.py
+++ b/TauAnalysisTools/test/runTauIdMVATrainingMiniAOD_deltaBeta_newDM.py
@@ -451,7 +451,7 @@ for discriminator in mvaDiscriminators.keys():
         cfg_modified += "\n"    
         cfg_modified += "delattr(process.makeROCcurveTauIdMVA, 'signalSamples')\n"
         cfg_modified += "delattr(process.makeROCcurveTauIdMVA, 'backgroundSamples')\n"
-        cfg_modified += "process.makeROCcurveTauIdMVA.treeName = cms.string('%s')\n" % tree
+        cfg_modified += "process.makeROCcurveTauIdMVA.treeName = cms.string('dataset/%s')\n" % tree
         ##cfg_modified += "process.makeROCcurveTauIdMVA.preselection = cms.string('%s')\n" % mvaDiscriminators[discriminator]['preselection']
         cfg_modified += "process.makeROCcurveTauIdMVA.preselection = cms.string('')\n"
         cfg_modified += "process.makeROCcurveTauIdMVA.classId_signal = cms.int32(0)\n"
@@ -557,7 +557,7 @@ else:
                 cfg_modified += "\n"
                 cfg_modified += "delattr(process.makeROCcurveTauIdMVA, 'signalSamples')\n"
                 cfg_modified += "delattr(process.makeROCcurveTauIdMVA, 'backgroundSamples')\n"
-                cfg_modified += "process.makeROCcurveTauIdMVA.treeName = cms.string('%s')\n" % tree
+                cfg_modified += "process.makeROCcurveTauIdMVA.treeName = cms.string('dataset/%s')\n" % tree
                 cfg_modified += "process.makeROCcurveTauIdMVA.preselection = cms.string('')\n"
                 cfg_modified += "process.makeROCcurveTauIdMVA.classId_signal = cms.int32(0)\n"
                 cfg_modified += "process.makeROCcurveTauIdMVA.classId_background = cms.int32(1)\n"

--- a/TauAnalysisTools/test/runTauIdMVATrainingMiniAOD_deltaBeta_newDM.py
+++ b/TauAnalysisTools/test/runTauIdMVATrainingMiniAOD_deltaBeta_newDM.py
@@ -11,9 +11,9 @@ train_option = 'optbDBAll'
 # apples-to-apples comparison!
 computeROConAllEvents = False
 
-inputFilePath  = "/nfs/dust/cms/user/anehrkor/TauIDMVATraining2016/Summer16_25ns_V2/ntuples/"
+inputFilePath  = "/nfs/dust/cms/user/anehrkor/TauIDMVATraining2017/PhaseIFall16_81X_upgrade2017_realistic_v1/ntuples/"
 
-outputFilePath = "/nfs/dust/cms/user/anehrkor/TauIDMVATraining2016/Summer16_25ns_V2/%s/trainfilesfinal_v1/" % version
+outputFilePath = "/nfs/dust/cms/user/anehrkor/TauIDMVATraining2017/PhaseIFall16_81X_upgrade2017_realistic_v1/%s/trainfilesfinal_v1/" % version
 
 preselection_oldDMs = \
     'decayModeFindingOldDMs > 0.5' \
@@ -75,56 +75,6 @@ mvaDiscriminators = {
         ],
         'legendEntry'         : "MVA opt1bLTDB",
         'color'               : 1
-    },
-    'mvaIsolation3HitsDeltaR05opt2bLTDB' : {
-        'preselection'        : preselection_newDMs,
-        'applyPtReweighting'  : True,
-        'applyEtaReweighting' : True,
-        'reweight'            : 'min:KILL',
-        'applyEventPruningSignal'   : 0, # no random pruning
-        'applyEventPruningBackground' : 0, # no random pruning
-        'applyPtDependentPruningSignal' : False, # no pt-dependent pruning
-        'applyPtDependentPruningBackground' : True, # pt-dependent pruning
-        'mvaTrainingOptions'  : "!H:!V:NTrees=1000:BoostType=Grad:Shrinkage=0.20:UseBaggedBoost:GradBaggingFraction=0.5:SeparationType=GiniIndex:nCuts=500:PruneMethod=NoPruning:MaxDepth=5",
-        'inputVariables'      : [
-            'TMath::Log(TMath::Max(1., recTauPt))/F',
-            'TMath::Abs(recTauEta)/F',
-            'TMath::Log(TMath::Max(1.e-2, chargedIsoPtSum))/F',
-            'TMath::Log(TMath::Max(1.e-2, neutralIsoPtSum))/F',
-            'TMath::Log(TMath::Max(1.e-2, puCorrPtSum))/F',
-            'recTauDecayMode/I',
-            'TMath::Min(30., recTauNphoton)/F',
-            'TMath::Min(0.5, recTauPtWeightedDetaStrip)/F',
-            'TMath::Min(0.5, recTauPtWeightedDphiStrip)/F',
-            'TMath::Min(0.5, recTauPtWeightedDrSignal)/F',
-            'TMath::Min(0.5, recTauPtWeightedDrIsolation)/F',
-            'TMath::Min(100., recTauLeadingTrackChi2)/F',
-            'TMath::Min(1., recTauEratio)/F',
-            'TMath::Sign(+1., recImpactParam)/F',
-            'TMath::Sqrt(TMath::Abs(TMath::Min(1., TMath::Abs(recImpactParam))))/F',
-            'TMath::Min(10., TMath::Abs(recImpactParamSign))/F',
-            'TMath::Sign(+1., recImpactParam3D)/F',
-            'TMath::Sqrt(TMath::Abs(TMath::Min(1., TMath::Abs(recImpactParam3D))))/F',
-            'TMath::Min(10., TMath::Abs(recImpactParamSign3D))/F',
-            'hasRecDecayVertex/I',
-            'TMath::Sqrt(recDecayDistMag)/F',
-            'TMath::Min(10., recDecayDistSign)/F'
-        ],
-        'spectatorVariables'  : [
-            ##'recTauPt/F',
-            'leadPFChargedHadrCandPt/F',
-            'numOfflinePrimaryVertices/I',
-            'genVisTauPt/F',
-            'genTauPt/F',
-            'byIsolationMVArun2v1DBnewDMwLTraw'#,
-            #'byLooseCombinedIsolationDeltaBetaCorr3Hits',
-            #'byMediumCombinedIsolationDeltaBetaCorr3Hits',
-            #'byTightCombinedIsolationDeltaBetaCorr3Hits'
-        ],
-        'otherVariables' : [
-        ],
-        'legendEntry'         : "MVA opt2bLTDB",
-        'color'               : 2
     }
 }
 
@@ -137,6 +87,15 @@ cutDiscriminators = {
         'max'                 : +1.5,
         'legendEntry'         : "2015 MVA",
         'color'               : 2
+    },
+    'rawMVAnewDMwLT2016' : {
+        'preselection'        : preselection_newDMs,
+        'discriminator'       : 'byIsolationMVArun2v1DBnewDMwLTraw2016',
+        'numBins'             : 30000,
+        'min'                 : -1.5,
+        'max'                 : +1.5,
+        'legendEntry'         : "2016 MVA",
+        'color'               : 3
     }#,
 #    'hpsCombinedIsolation3HitsLooseNewDMs' : {
 #        'preselection'        : preselection_newDMs,
@@ -175,8 +134,8 @@ plots = {
 'mvaIsolation_optDeltaR05BDeltaBeta' : {
         'graphs' : [
             'mvaIsolation3HitsDeltaR05opt1bLTDB',
-            'mvaIsolation3HitsDeltaR05opt2bLTDB',
-            'rawMVAnewDMwLT'#,
+            'rawMVAnewDMwLT',
+            'rawMVAnewDMwLT2016'#,
 #            'hpsCombinedIsolation3HitsLooseNewDMs',
 #            'hpsCombinedIsolation3HitsMediumNewDMs',
 #            'hpsCombinedIsolation3HitsTightNewDMs'
@@ -189,56 +148,56 @@ allDiscriminators.update(mvaDiscriminators)
 allDiscriminators.update(cutDiscriminators)
 
 signalSamples = [
-    "ZplusJets_mcatnlo"
+    "ZplusJets_madgraph"
 ]
-smHiggsMassPoints = [ 120, 125, 130 ]
-for massPoint in smHiggsMassPoints:
-    wPlusHSampleName = "WplusHHiggs%1.0ftoTauTau" % massPoint
-    signalSamples.append(wPlusHSampleName)
-    wMinusHSampleName = "WminusHHiggs%1.0ftoTauTau" % massPoint
-    signalSamples.append(wMinusHSampleName)
-    zHSampleName = "ZHHiggs%1.0ftoTauTau" % massPoint
-    signalSamples.append(zHSampleName)
-smHiggsMassPoints5 = [ 120, 130 ]
-for massPoint in smHiggsMassPoints5:
-    tthSampleName = "tthHiggs%1.0ftoTauTau" % massPoint
-    signalSamples.append(tthSampleName)
-ggSampleName = "ggHiggs125toTauTau"
-signalSamples.append(ggSampleName)
-vbfSampleName = "vbfHiggs125toTauTau"
-signalSamples.append(vbfSampleName)
-mssmHiggsMassPoints1 = [ 80, 90, 100, 110, 120, 130, 160, 180, 200, 250, 300, 350, 400, 450, 500, 600, 700, 800, 1000, 1200, 1400, 1500, 1600, 1800, 2000, 2300, 2600, 2900, 3200 ]
+#smHiggsMassPoints = [ 120, 125, 130 ]
+#for massPoint in smHiggsMassPoints:
+#    wPlusHSampleName = "WplusHHiggs%1.0ftoTauTau" % massPoint
+#    signalSamples.append(wPlusHSampleName)
+#    wMinusHSampleName = "WminusHHiggs%1.0ftoTauTau" % massPoint
+#    signalSamples.append(wMinusHSampleName)
+#    zHSampleName = "ZHHiggs%1.0ftoTauTau" % massPoint
+#    signalSamples.append(zHSampleName)
+#smHiggsMassPoints5 = [ 120, 130 ]
+#for massPoint in smHiggsMassPoints5:
+#    tthSampleName = "tthHiggs%1.0ftoTauTau" % massPoint
+#    signalSamples.append(tthSampleName)
+#ggSampleName = "ggHiggs125toTauTau"
+#signalSamples.append(ggSampleName)
+#vbfSampleName = "vbfHiggs125toTauTau"
+#signalSamples.append(vbfSampleName)
+mssmHiggsMassPoints1 = [ 140, 160, 180, 200, 250, 300, 350, 400, 450, 500, 600, 700, 800, 900, 1000, 1200, 1400, 1600, 1800, 2000, 2300, 2600, 2900 ]
 for massPoint in mssmHiggsMassPoints1:
     ggSampleName = "ggA%1.0ftoTauTau" % massPoint
     signalSamples.append(ggSampleName)
-mssmHiggsMassPoints2 = [ 80, 90, 100, 110, 120, 130, 140, 160, 180, 200, 250, 300, 350, 400, 450, 500, 600, 700, 800, 900, 1000, 1200, 1400, 1500, 1600, 1800, 2000, 2300, 2600, 2900, 3200 ]
+mssmHiggsMassPoints2 = [ 140, 160, 180, 200, 250, 300, 350, 400, 450, 500, 600, 700, 800, 900, 1000, 1200, 1400, 1600, 1800, 2000, 2300, 2600, 3200 ]
 for massPoint in mssmHiggsMassPoints2:
     bbSampleName = "bbA%1.0ftoTauTau" % massPoint
     signalSamples.append(bbSampleName)
-ZprimeMassPoints = [ 500, 750, 1000, 1250, 1500, 1750, 2000, 2500, 3000, 3500, 4000 ]
+ZprimeMassPoints = [ 750, 1000, 1250, 1750, 2000, 2500, 3000, 3500, 4000 ]
 for massPoint in ZprimeMassPoints:
     sampleName = "Zprime%1.0ftoTauTau" % massPoint
     signalSamples.append(sampleName)
-WprimeMassPoints = [ 400, 600, 1000, 1200, 1400, 1600, 1800, 2000, 2200, 2400, 2600, 2800, 3000, 3200, 3400, 3600, 3800, 4000, 4200, 4400, 4600, 4800, 5000, 5200, 5400, 5600, 5800 ]
-for massPoint in WprimeMassPoints:
-    sampleName = "Wprime%1.0ftoTauNu" % massPoint
-    signalSamples.append(sampleName)
+#WprimeMassPoints = [ 400, 600, 1000, 1200, 1400, 1600, 1800, 2000, 2200, 2400, 2600, 2800, 3000, 3200, 3400, 3600, 3800, 4000, 4200, 4400, 4600, 4800, 5000, 5200, 5400, 5600, 5800 ]
+#for massPoint in WprimeMassPoints:
+#    sampleName = "Wprime%1.0ftoTauNu" % massPoint
+#    signalSamples.append(sampleName)
 
 backgroundSamples = [
     "TT_powheg",
-    "PPmuXptGt20Mu15",
-    "QCDmuEnrichedPt30to50",
-    "QCDmuEnrichedPt50to80",
-    "QCDmuEnrichedPt80to120",
-    "QCDmuEnrichedPt120to170",
-    "QCDmuEnrichedPt170to300",
-    "QCDmuEnrichedPt300to470",
-    "QCDmuEnrichedPt470to600",
-    "QCDmuEnrichedPt600to800",
-    "QCDmuEnrichedPt800to1000",
-    "QCDmuEnrichedPtGt1000",
-    "WplusJets_mcatnlo",
-    "QCDjetsFlatPt15to7000",
+#    "PPmuXptGt20Mu15",
+#    "QCDmuEnrichedPt30to50",
+#    "QCDmuEnrichedPt50to80",
+#    "QCDmuEnrichedPt80to120",
+#    "QCDmuEnrichedPt120to170",
+#    "QCDmuEnrichedPt170to300",
+#    "QCDmuEnrichedPt300to470",
+#    "QCDmuEnrichedPt470to600",
+#    "QCDmuEnrichedPt600to800",
+#    "QCDmuEnrichedPt800to1000",
+#    "QCDmuEnrichedPtGt1000",
+    "WplusJets_madgraph",
+#    "QCDjetsFlatPt15to7000",
     "QCDjetsPt30to50",
     "QCDjetsPt50to80",
     "QCDjetsPt80to120",
@@ -250,15 +209,15 @@ backgroundSamples = [
     "QCDjetsPt800to1000",
     "QCDjetsPt1000to1400",
     "QCDjetsPt1400to1800",
-    "QCDjetsPt1800to2400",
+#    "QCDjetsPt1800to2400",
     "QCDjetsPt2400to3200",
     "QCDjetsPtGt3200",
-    "QCDEmEnrichedPt20to30",
-    "QCDEmEnrichedPt30to50",
-    "QCDEmEnrichedPt50to80",
-    "QCDEmEnrichedPt80to120",
-    "QCDEmEnrichedPt170to300",
-    "QCDEmEnrichedPtGt300"
+#    "QCDEmEnrichedPt20to30",
+#    "QCDEmEnrichedPt30to50",
+#    "QCDEmEnrichedPt50to80",
+#    "QCDEmEnrichedPt80to120",
+#    "QCDEmEnrichedPt170to300",
+#    "QCDEmEnrichedPtGt300"
 ]
 
 execDir = "%s/bin/%s/" % (os.environ['CMSSW_BASE'], os.environ['SCRAM_ARCH'])

--- a/TauAnalysisTools/test/runTauIdMVATrainingMiniAOD_deltaBeta_newDM.py
+++ b/TauAnalysisTools/test/runTauIdMVATrainingMiniAOD_deltaBeta_newDM.py
@@ -66,7 +66,8 @@ mvaDiscriminators = {
             'numOfflinePrimaryVertices/I',
             'genVisTauPt/F',
             'genTauPt/F',
-            'byIsolationMVArun2v1DBnewDMwLTraw'#,
+            'byIsolationMVArun2v1DBnewDMwLTraw',
+            'byIsolationMVArun2v1DBnewDMwLTraw2016'#,
             #'byLooseCombinedIsolationDeltaBetaCorr3Hits',
             #'byMediumCombinedIsolationDeltaBetaCorr3Hits',
             #'byTightCombinedIsolationDeltaBetaCorr3Hits'

--- a/TauAnalysisTools/test/runTauIdMVATrainingMiniAOD_deltaBeta_newDM.py
+++ b/TauAnalysisTools/test/runTauIdMVATrainingMiniAOD_deltaBeta_newDM.py
@@ -48,7 +48,6 @@ mvaDiscriminators = {
             'TMath::Min(0.5, recTauPtWeightedDphiStrip)/F',
             'TMath::Min(0.5, recTauPtWeightedDrSignal)/F',
             'TMath::Min(0.5, recTauPtWeightedDrIsolation)/F',
-            'TMath::Min(100., recTauLeadingTrackChi2)/F',
             'TMath::Min(1., recTauEratio)/F',
             'TMath::Sign(+1., recImpactParam)/F',
             'TMath::Sqrt(TMath::Abs(TMath::Min(1., TMath::Abs(recImpactParam))))/F',
@@ -58,7 +57,8 @@ mvaDiscriminators = {
             'TMath::Min(10., TMath::Abs(recImpactParamSign3D))/F',
             'hasRecDecayVertex/I',
             'TMath::Sqrt(recDecayDistMag)/F',
-            'TMath::Min(10., recDecayDistSign)/F'
+            'TMath::Min(10., recDecayDistSign)/F',
+            'TMath::Max(-1.,recTauGJangleDiff)/F'
         ],
         'spectatorVariables'  : [
             ##'recTauPt/F',

--- a/TauAnalysisTools/test/runTauIdMVATrainingMiniAOD_deltaBeta_oldDM.py
+++ b/TauAnalysisTools/test/runTauIdMVATrainingMiniAOD_deltaBeta_oldDM.py
@@ -451,7 +451,7 @@ for discriminator in mvaDiscriminators.keys():
         cfg_modified += "\n"    
         cfg_modified += "delattr(process.makeROCcurveTauIdMVA, 'signalSamples')\n"
         cfg_modified += "delattr(process.makeROCcurveTauIdMVA, 'backgroundSamples')\n"
-        cfg_modified += "process.makeROCcurveTauIdMVA.treeName = cms.string('%s')\n" % tree
+        cfg_modified += "process.makeROCcurveTauIdMVA.treeName = cms.string('dataset/%s')\n" % tree
         ##cfg_modified += "process.makeROCcurveTauIdMVA.preselection = cms.string('%s')\n" % mvaDiscriminators[discriminator]['preselection']
         cfg_modified += "process.makeROCcurveTauIdMVA.preselection = cms.string('')\n"
         cfg_modified += "process.makeROCcurveTauIdMVA.classId_signal = cms.int32(0)\n"
@@ -557,7 +557,7 @@ else:
                 cfg_modified += "\n"
                 cfg_modified += "delattr(process.makeROCcurveTauIdMVA, 'signalSamples')\n"
                 cfg_modified += "delattr(process.makeROCcurveTauIdMVA, 'backgroundSamples')\n"
-                cfg_modified += "process.makeROCcurveTauIdMVA.treeName = cms.string('%s')\n" % tree
+                cfg_modified += "process.makeROCcurveTauIdMVA.treeName = cms.string('dataset/%s')\n" % tree
                 cfg_modified += "process.makeROCcurveTauIdMVA.preselection = cms.string('')\n"
                 cfg_modified += "process.makeROCcurveTauIdMVA.classId_signal = cms.int32(0)\n"
                 cfg_modified += "process.makeROCcurveTauIdMVA.classId_background = cms.int32(1)\n"

--- a/TauAnalysisTools/test/runTauIdMVATrainingMiniAOD_deltaBeta_oldDM.py
+++ b/TauAnalysisTools/test/runTauIdMVATrainingMiniAOD_deltaBeta_oldDM.py
@@ -11,9 +11,9 @@ train_option = 'optaDBAll'
 # apples-to-apples comparison!
 computeROConAllEvents = False
 
-inputFilePath  = "/nfs/dust/cms/user/anehrkor/TauIDMVATraining2016/Summer16_25ns_V2/ntuples/"
+inputFilePath  = "/nfs/dust/cms/user/anehrkor/TauIDMVATraining2017/PhaseIFall16_81X_upgrade2017_realistic_v1/ntuples/"
 
-outputFilePath = "/nfs/dust/cms/user/anehrkor/TauIDMVATraining2016/Summer16_25ns_V2/%s/trainfilesfinal_v1/" % version
+outputFilePath = "/nfs/dust/cms/user/anehrkor/TauIDMVATraining2017/PhaseIFall16_81X_upgrade2017_realistic_v1/%s/trainfilesfinal_v1/" % version
 
 preselection_oldDMs = \
     'decayModeFindingOldDMs > 0.5' \
@@ -75,56 +75,6 @@ mvaDiscriminators = {
         ],
         'legendEntry'         : "MVA opt1aLTDB",
         'color'               : 1
-    },
-    'mvaIsolation3HitsDeltaR05opt2aLTDB' : {
-        'preselection'        : preselection_oldDMs,
-        'applyPtReweighting'  : True,
-        'applyEtaReweighting' : True,
-        'reweight'            : 'min:KILL',
-        'applyEventPruningSignal'   : 0, # no random pruning
-        'applyEventPruningBackground' : 0, # no random pruning
-        'applyPtDependentPruningSignal' : False, # no pt-dependent pruning
-        'applyPtDependentPruningBackground' : True, # pt-dependent pruning
-        'mvaTrainingOptions'  : "!H:!V:NTrees=1000:BoostType=Grad:Shrinkage=0.20:UseBaggedBoost:GradBaggingFraction=0.5:SeparationType=GiniIndex:nCuts=500:PruneMethod=NoPruning:MaxDepth=5",
-        'inputVariables'      : [
-            'TMath::Log(TMath::Max(1., recTauPt))/F',
-            'TMath::Abs(recTauEta)/F',
-            'TMath::Log(TMath::Max(1.e-2, chargedIsoPtSum))/F',
-            'TMath::Log(TMath::Max(1.e-2, neutralIsoPtSum))/F',
-            'TMath::Log(TMath::Max(1.e-2, puCorrPtSum))/F',
-            'recTauDecayMode/I',
-            'TMath::Min(30., recTauNphoton)/F',
-            'TMath::Min(0.5, recTauPtWeightedDetaStrip)/F',
-            'TMath::Min(0.5, recTauPtWeightedDphiStrip)/F',
-            'TMath::Min(0.5, recTauPtWeightedDrSignal)/F',
-            'TMath::Min(0.5, recTauPtWeightedDrIsolation)/F',
-            'TMath::Min(100., recTauLeadingTrackChi2)/F',
-            'TMath::Min(1., recTauEratio)/F',
-            'TMath::Sign(+1., recImpactParam)/F',
-            'TMath::Sqrt(TMath::Abs(TMath::Min(1., TMath::Abs(recImpactParam))))/F',
-            'TMath::Min(10., TMath::Abs(recImpactParamSign))/F',
-            'TMath::Sign(+1., recImpactParam3D)/F',
-            'TMath::Sqrt(TMath::Abs(TMath::Min(1., TMath::Abs(recImpactParam3D))))/F',
-            'TMath::Min(10., TMath::Abs(recImpactParamSign3D))/F',
-            'hasRecDecayVertex/I',
-            'TMath::Sqrt(recDecayDistMag)/F',
-            'TMath::Min(10., recDecayDistSign)/F'
-        ],
-        'spectatorVariables'  : [
-            ##'recTauPt/F',
-            'leadPFChargedHadrCandPt/F',
-            'numOfflinePrimaryVertices/I',
-            'genVisTauPt/F',
-            'genTauPt/F',
-            'byIsolationMVArun2v1DBoldDMwLTraw'#,
-            #'byLooseCombinedIsolationDeltaBetaCorr3Hits',
-            #'byMediumCombinedIsolationDeltaBetaCorr3Hits',
-            #'byTightCombinedIsolationDeltaBetaCorr3Hits'
-        ],
-        'otherVariables' : [
-        ],
-        'legendEntry'         : "MVA opt2aLTDB",
-        'color'               : 2
     }
 }
 
@@ -137,6 +87,15 @@ cutDiscriminators = {
         'max'                 : +1.5,
         'legendEntry'         : "2015 MVA",
         'color'               : 2
+    },
+    'rawMVAoldDMwLT2016' : {
+        'preselection'        : preselection_oldDMs,
+        'discriminator'       : 'byIsolationMVArun2v1DBoldDMwLTraw2016',
+        'numBins'             : 30000,
+        'min'                 : -1.5,
+        'max'                 : +1.5,
+        'legendEntry'         : "2016 MVA",
+        'color'               : 3
     }#,
 #    'hpsCombinedIsolation3HitsLooseOldDMs' : {
 #        'preselection'        : preselection_oldDMs,
@@ -175,8 +134,8 @@ plots = {
 'mvaIsolation_optDeltaR05BDeltaBeta' : {
         'graphs' : [
             'mvaIsolation3HitsDeltaR05opt1aLTDB',
-            'mvaIsolation3HitsDeltaR05opt2aLTDB',
-            'rawMVAoldDMwLT'#,
+            'rawMVAoldDMwLT',
+            'rawMVAoldDMwLT2016'#,
 #            'hpsCombinedIsolation3HitsLooseOldDMs',
 #            'hpsCombinedIsolation3HitsMediumOldDMs',
 #            'hpsCombinedIsolation3HitsTightOldDMs'
@@ -189,56 +148,56 @@ allDiscriminators.update(mvaDiscriminators)
 allDiscriminators.update(cutDiscriminators)
 
 signalSamples = [
-    "ZplusJets_mcatnlo"
+    "ZplusJets_madgraph"
 ]
-smHiggsMassPoints = [ 120, 125, 130 ]
-for massPoint in smHiggsMassPoints:
-    wPlusHSampleName = "WplusHHiggs%1.0ftoTauTau" % massPoint
-    signalSamples.append(wPlusHSampleName)
-    wMinusHSampleName = "WminusHHiggs%1.0ftoTauTau" % massPoint
-    signalSamples.append(wMinusHSampleName)
-    zHSampleName = "ZHHiggs%1.0ftoTauTau" % massPoint
-    signalSamples.append(zHSampleName)
-smHiggsMassPoints5 = [ 120, 130 ]
-for massPoint in smHiggsMassPoints5:
-    tthSampleName = "tthHiggs%1.0ftoTauTau" % massPoint
-    signalSamples.append(tthSampleName)
-ggSampleName = "ggHiggs125toTauTau"
-signalSamples.append(ggSampleName)
-vbfSampleName = "vbfHiggs125toTauTau"
-signalSamples.append(vbfSampleName)
-mssmHiggsMassPoints1 = [ 80, 90, 100, 110, 120, 130, 160, 180, 200, 250, 300, 350, 400, 450, 500, 600, 700, 800, 1000, 1200, 1400, 1500, 1600, 1800, 2000, 2300, 2600, 2900, 3200 ]
+#smHiggsMassPoints = [ 120, 125, 130 ]
+#for massPoint in smHiggsMassPoints:
+#    wPlusHSampleName = "WplusHHiggs%1.0ftoTauTau" % massPoint
+#    signalSamples.append(wPlusHSampleName)
+#    wMinusHSampleName = "WminusHHiggs%1.0ftoTauTau" % massPoint
+#    signalSamples.append(wMinusHSampleName)
+#    zHSampleName = "ZHHiggs%1.0ftoTauTau" % massPoint
+#    signalSamples.append(zHSampleName)
+#smHiggsMassPoints5 = [ 120, 130 ]
+#for massPoint in smHiggsMassPoints5:
+#    tthSampleName = "tthHiggs%1.0ftoTauTau" % massPoint
+#    signalSamples.append(tthSampleName)
+#ggSampleName = "ggHiggs125toTauTau"
+#signalSamples.append(ggSampleName)
+#vbfSampleName = "vbfHiggs125toTauTau"
+#signalSamples.append(vbfSampleName)
+mssmHiggsMassPoints1 = [ 140, 160, 180, 200, 250, 300, 350, 400, 450, 500, 600, 700, 800, 900, 1000, 1200, 1400, 1600, 1800, 2000, 2300, 2600, 2900 ]
 for massPoint in mssmHiggsMassPoints1:
     ggSampleName = "ggA%1.0ftoTauTau" % massPoint
     signalSamples.append(ggSampleName)
-mssmHiggsMassPoints2 = [ 80, 90, 100, 110, 120, 130, 140, 160, 180, 200, 250, 300, 350, 400, 450, 500, 600, 700, 800, 900, 1000, 1200, 1400, 1500, 1600, 1800, 2000, 2300, 2600, 2900, 3200 ]
+mssmHiggsMassPoints2 = [ 140, 160, 180, 200, 250, 300, 350, 400, 450, 500, 600, 700, 800, 900, 1000, 1200, 1400, 1600, 1800, 2000, 2300, 2600, 3200 ]
 for massPoint in mssmHiggsMassPoints2:
     bbSampleName = "bbA%1.0ftoTauTau" % massPoint
     signalSamples.append(bbSampleName)
-ZprimeMassPoints = [ 500, 750, 1000, 1250, 1500, 1750, 2000, 2500, 3000, 3500, 4000 ]
+ZprimeMassPoints = [ 750, 1000, 1250, 1750, 2000, 2500, 3000, 3500, 4000 ]
 for massPoint in ZprimeMassPoints:
     sampleName = "Zprime%1.0ftoTauTau" % massPoint
     signalSamples.append(sampleName)
-WprimeMassPoints = [ 400, 600, 1000, 1200, 1400, 1600, 1800, 2000, 2200, 2400, 2600, 2800, 3000, 3200, 3400, 3600, 3800, 4000, 4200, 4400, 4600, 4800, 5000, 5200, 5400, 5600, 5800 ]
-for massPoint in WprimeMassPoints:
-    sampleName = "Wprime%1.0ftoTauNu" % massPoint
-    signalSamples.append(sampleName)
+#WprimeMassPoints = [ 400, 600, 1000, 1200, 1400, 1600, 1800, 2000, 2200, 2400, 2600, 2800, 3000, 3200, 3400, 3600, 3800, 4000, 4200, 4400, 4600, 4800, 5000, 5200, 5400, 5600, 5800 ]
+#for massPoint in WprimeMassPoints:
+#    sampleName = "Wprime%1.0ftoTauNu" % massPoint
+#    signalSamples.append(sampleName)
 
 backgroundSamples = [
     "TT_powheg",
-    "PPmuXptGt20Mu15",
-    "QCDmuEnrichedPt30to50",
-    "QCDmuEnrichedPt50to80",
-    "QCDmuEnrichedPt80to120",
-    "QCDmuEnrichedPt120to170",
-    "QCDmuEnrichedPt170to300",
-    "QCDmuEnrichedPt300to470",
-    "QCDmuEnrichedPt470to600",
-    "QCDmuEnrichedPt600to800",
-    "QCDmuEnrichedPt800to1000",
-    "QCDmuEnrichedPtGt1000",
-    "WplusJets_mcatnlo",
-    "QCDjetsFlatPt15to7000",
+#    "PPmuXptGt20Mu15",
+#    "QCDmuEnrichedPt30to50",
+#    "QCDmuEnrichedPt50to80",
+#    "QCDmuEnrichedPt80to120",
+#    "QCDmuEnrichedPt120to170",
+#    "QCDmuEnrichedPt170to300",
+#    "QCDmuEnrichedPt300to470",
+#    "QCDmuEnrichedPt470to600",
+#    "QCDmuEnrichedPt600to800",
+#    "QCDmuEnrichedPt800to1000",
+#    "QCDmuEnrichedPtGt1000",
+    "WplusJets_madgraph",
+#    "QCDjetsFlatPt15to7000",
     "QCDjetsPt30to50",
     "QCDjetsPt50to80",
     "QCDjetsPt80to120",
@@ -250,15 +209,15 @@ backgroundSamples = [
     "QCDjetsPt800to1000",
     "QCDjetsPt1000to1400",
     "QCDjetsPt1400to1800",
-    "QCDjetsPt1800to2400",
+#    "QCDjetsPt1800to2400",
     "QCDjetsPt2400to3200",
     "QCDjetsPtGt3200",
-    "QCDEmEnrichedPt20to30",
-    "QCDEmEnrichedPt30to50",
-    "QCDEmEnrichedPt50to80",
-    "QCDEmEnrichedPt80to120",
-    "QCDEmEnrichedPt170to300",
-    "QCDEmEnrichedPtGt300"
+#    "QCDEmEnrichedPt20to30",
+#    "QCDEmEnrichedPt30to50",
+#    "QCDEmEnrichedPt50to80",
+#    "QCDEmEnrichedPt80to120",
+#    "QCDEmEnrichedPt170to300",
+#    "QCDEmEnrichedPtGt300"
 ]
 
 execDir = "%s/bin/%s/" % (os.environ['CMSSW_BASE'], os.environ['SCRAM_ARCH'])

--- a/TauAnalysisTools/test/runTauIdMVATrainingMiniAOD_deltaBeta_oldDM.py
+++ b/TauAnalysisTools/test/runTauIdMVATrainingMiniAOD_deltaBeta_oldDM.py
@@ -48,7 +48,6 @@ mvaDiscriminators = {
             'TMath::Min(0.5, recTauPtWeightedDphiStrip)/F',
             'TMath::Min(0.5, recTauPtWeightedDrSignal)/F',
             'TMath::Min(0.5, recTauPtWeightedDrIsolation)/F',
-            'TMath::Min(100., recTauLeadingTrackChi2)/F',
             'TMath::Min(1., recTauEratio)/F',
             'TMath::Sign(+1., recImpactParam)/F',
             'TMath::Sqrt(TMath::Abs(TMath::Min(1., TMath::Abs(recImpactParam))))/F',
@@ -58,7 +57,8 @@ mvaDiscriminators = {
             'TMath::Min(10., TMath::Abs(recImpactParamSign3D))/F',
             'hasRecDecayVertex/I',
             'TMath::Sqrt(recDecayDistMag)/F',
-            'TMath::Min(10., recDecayDistSign)/F'
+            'TMath::Min(10., recDecayDistSign)/F',
+            'TMath::Max(-1.,recTauGJangleDiff)/F'
         ],
         'spectatorVariables'  : [
             ##'recTauPt/F',

--- a/TauAnalysisTools/test/runTauIdMVATrainingMiniAOD_deltaBeta_oldDM.py
+++ b/TauAnalysisTools/test/runTauIdMVATrainingMiniAOD_deltaBeta_oldDM.py
@@ -66,7 +66,8 @@ mvaDiscriminators = {
             'numOfflinePrimaryVertices/I',
             'genVisTauPt/F',
             'genTauPt/F',
-            'byIsolationMVArun2v1DBoldDMwLTraw'#,
+            'byIsolationMVArun2v1DBoldDMwLTraw',
+            'byIsolationMVArun2v1DBoldDMwLTraw2016'#,
             #'byLooseCombinedIsolationDeltaBetaCorr3Hits',
             #'byMediumCombinedIsolationDeltaBetaCorr3Hits',
             #'byTightCombinedIsolationDeltaBetaCorr3Hits'

--- a/TauAnalysisTools/test/runTauIdMVATraining_deltaBeta_newDM.py
+++ b/TauAnalysisTools/test/runTauIdMVATraining_deltaBeta_newDM.py
@@ -1403,7 +1403,7 @@ for discriminator in mvaDiscriminators.keys():
         cfg_modified += "\n"    
         cfg_modified += "delattr(process.makeROCcurveTauIdMVA, 'signalSamples')\n"
         cfg_modified += "delattr(process.makeROCcurveTauIdMVA, 'backgroundSamples')\n"
-        cfg_modified += "process.makeROCcurveTauIdMVA.treeName = cms.string('%s')\n" % tree
+        cfg_modified += "process.makeROCcurveTauIdMVA.treeName = cms.string('dataset/%s')\n" % tree
         ##cfg_modified += "process.makeROCcurveTauIdMVA.preselection = cms.string('%s')\n" % mvaDiscriminators[discriminator]['preselection']
         cfg_modified += "process.makeROCcurveTauIdMVA.preselection = cms.string('')\n"
         cfg_modified += "process.makeROCcurveTauIdMVA.classId_signal = cms.int32(0)\n"

--- a/TauAnalysisTools/test/runTauIdMVATraining_deltaBeta_oldDM.py
+++ b/TauAnalysisTools/test/runTauIdMVATraining_deltaBeta_oldDM.py
@@ -1400,7 +1400,7 @@ for discriminator in mvaDiscriminators.keys():
         cfg_modified += "\n"    
         cfg_modified += "delattr(process.makeROCcurveTauIdMVA, 'signalSamples')\n"
         cfg_modified += "delattr(process.makeROCcurveTauIdMVA, 'backgroundSamples')\n"
-        cfg_modified += "process.makeROCcurveTauIdMVA.treeName = cms.string('%s')\n" % tree
+        cfg_modified += "process.makeROCcurveTauIdMVA.treeName = cms.string('dataset/%s')\n" % tree
         ##cfg_modified += "process.makeROCcurveTauIdMVA.preselection = cms.string('%s')\n" % mvaDiscriminators[discriminator]['preselection']
         cfg_modified += "process.makeROCcurveTauIdMVA.preselection = cms.string('')\n"
         cfg_modified += "process.makeROCcurveTauIdMVA.classId_signal = cms.int32(0)\n"

--- a/TauAnalysisTools/test/runTauIdMVATraining_puWeight_newDM.py
+++ b/TauAnalysisTools/test/runTauIdMVATraining_puWeight_newDM.py
@@ -1403,7 +1403,7 @@ for discriminator in mvaDiscriminators.keys():
         cfg_modified += "\n"    
         cfg_modified += "delattr(process.makeROCcurveTauIdMVA, 'signalSamples')\n"
         cfg_modified += "delattr(process.makeROCcurveTauIdMVA, 'backgroundSamples')\n"
-        cfg_modified += "process.makeROCcurveTauIdMVA.treeName = cms.string('%s')\n" % tree
+        cfg_modified += "process.makeROCcurveTauIdMVA.treeName = cms.string('dataset/%s')\n" % tree
         ##cfg_modified += "process.makeROCcurveTauIdMVA.preselection = cms.string('%s')\n" % mvaDiscriminators[discriminator]['preselection']
         cfg_modified += "process.makeROCcurveTauIdMVA.preselection = cms.string('')\n"
         cfg_modified += "process.makeROCcurveTauIdMVA.classId_signal = cms.int32(0)\n"

--- a/TauAnalysisTools/test/runTauIdMVATraining_puWeight_oldDM.py
+++ b/TauAnalysisTools/test/runTauIdMVATraining_puWeight_oldDM.py
@@ -1400,7 +1400,7 @@ for discriminator in mvaDiscriminators.keys():
         cfg_modified += "\n"    
         cfg_modified += "delattr(process.makeROCcurveTauIdMVA, 'signalSamples')\n"
         cfg_modified += "delattr(process.makeROCcurveTauIdMVA, 'backgroundSamples')\n"
-        cfg_modified += "process.makeROCcurveTauIdMVA.treeName = cms.string('%s')\n" % tree
+        cfg_modified += "process.makeROCcurveTauIdMVA.treeName = cms.string('dataset/%s')\n" % tree
         ##cfg_modified += "process.makeROCcurveTauIdMVA.preselection = cms.string('%s')\n" % mvaDiscriminators[discriminator]['preselection']
         cfg_modified += "process.makeROCcurveTauIdMVA.preselection = cms.string('')\n"
         cfg_modified += "process.makeROCcurveTauIdMVA.classId_signal = cms.int32(0)\n"

--- a/TauAnalysisTools/test/runTauIdMVATraining_test.py
+++ b/TauAnalysisTools/test/runTauIdMVATraining_test.py
@@ -957,7 +957,7 @@ for discriminator in mvaDiscriminators.keys():
         cfg_modified += "\n"    
         cfg_modified += "delattr(process.makeROCcurveTauIdMVA, 'signalSamples')\n"
         cfg_modified += "delattr(process.makeROCcurveTauIdMVA, 'backgroundSamples')\n"
-        cfg_modified += "process.makeROCcurveTauIdMVA.treeName = cms.string('%s')\n" % tree
+        cfg_modified += "process.makeROCcurveTauIdMVA.treeName = cms.string('dataset/%s')\n" % tree
         ##cfg_modified += "process.makeROCcurveTauIdMVA.preselection = cms.string('%s')\n" % mvaDiscriminators[discriminator]['preselection']
         cfg_modified += "process.makeROCcurveTauIdMVA.preselection = cms.string('')\n"
         cfg_modified += "process.makeROCcurveTauIdMVA.classId_signal = cms.int32(0)\n"

--- a/TauAnalysisTools/test/submitTauIdMVATrainingNtupleProduction_crab3.py
+++ b/TauAnalysisTools/test/submitTauIdMVATrainingNtupleProduction_crab3.py
@@ -9,331 +9,341 @@ import subprocess
 import time
 
 samples = {
-    'ZplusJets_mcatnlo' : {
-        'datasetpath'                        : '/DYJetsToLL_M-50_TuneCUETP8M1_13TeV-amcatnloFXFX-pythia8/RunIISummer16MiniAODv2-PUMoriond17_HCALDebug_80X_mcRun2_asymptotic_2016_TrancheIV_v6-v1/MINIAODSIM',
+    'ZplusJets_madgraph' : {
+        'datasetpath'                        : '/DYJetsToLL_M-50_TuneCUETP8M1_13TeV-madgraphMLM-pythia8/PhaseIFall16MiniAOD-PhaseIFall16PUFlat20to50_PhaseIFall16_81X_upgrade2017_realistic_v26_ext1-v1/MINIAODSIM',
         'files_per_job'                      : 1,
         'total_files'                        : -1,
         'type'                               : 'SignalMC'
     },
     'TT_powheg': {
-        'datasetpath'                        : '/TT_TuneCUETP8M2T4_13TeV-powheg-pythia8/RunIISummer16MiniAODv2-PUMoriond17_80X_mcRun2_asymptotic_2016_TrancheIV_v6-v1/MINIAODSIM',
+        'datasetpath'                        : '/TT_TuneCUETP8M2T4_13TeV-powheg-pythia8/PhaseIFall16MiniAOD-PhaseIFall16PUFlat20to50_PhaseIFall16_81X_upgrade2017_realistic_v26-v1/MINIAODSIM',
         'files_per_job'                      : 1,
         'total_files'                        : -1,
         'type'                               : 'BackgroundMC'
     },
-    'PPmuXptGt20Mu15' : {
-        'datasetpath'                        : '/QCD_Pt-20toInf_MuEnrichedPt15_TuneCUETP8M1_13TeV_pythia8/RunIISummer16MiniAODv2-PUMoriond17_80X_mcRun2_asymptotic_2016_TrancheIV_v6-v1/MINIAODSIM',
+#    'PPmuXptGt20Mu15' : {
+#        'datasetpath'                        : '/QCD_Pt-20toInf_MuEnrichedPt15_TuneCUETP8M1_13TeV_pythia8/RunIISummer16MiniAODv2-PUMoriond17_80X_mcRun2_asymptotic_2016_TrancheIV_v6-v1/MINIAODSIM',
+#        'files_per_job'                      : 1,
+#        'total_files'                        : -1,
+#        'type'                               : 'BackgroundMC'
+#    },
+#    'QCDmuEnrichedPt30to50' : {
+#        'datasetpath'                        : '/QCD_Pt-30to50_MuEnrichedPt5_TuneCUETP8M1_13TeV_pythia8/RunIISummer16MiniAODv2-PUMoriond17_80X_mcRun2_asymptotic_2016_TrancheIV_v6-v1/MINIAODSIM',
+#        'files_per_job'                      : 1,
+#        'total_files'                        : -1,
+#        'type'                               : 'BackgroundMC'
+#    },
+#    'QCDmuEnrichedPt50to80' : {
+#        'datasetpath'                        : '/QCD_Pt-50to80_MuEnrichedPt5_TuneCUETP8M1_13TeV_pythia8/RunIISummer16MiniAODv2-PUMoriond17_80X_mcRun2_asymptotic_2016_TrancheIV_v6-v1/MINIAODSIM',
+#        'files_per_job'                      : 1,
+#        'total_files'                        : -1,
+#        'type'                               : 'BackgroundMC'
+#    },
+#    'QCDmuEnrichedPt80to120' : {
+#        'datasetpath'                        : '/QCD_Pt-80to120_MuEnrichedPt5_TuneCUETP8M1_13TeV_pythia8/RunIISummer16MiniAODv2-PUMoriond17_80X_mcRun2_asymptotic_2016_TrancheIV_v6-v1/MINIAODSIM',
+#        'files_per_job'                      : 1,
+#        'total_files'                        : -1,
+#        'type'                               : 'BackgroundMC'
+#    },
+#    'QCDmuEnrichedPt120to170' : {
+#        'datasetpath'                        : '/QCD_Pt-120to170_MuEnrichedPt5_TuneCUETP8M1_13TeV_pythia8/RunIISummer16MiniAODv2-PUMoriond17_80X_mcRun2_asymptotic_2016_TrancheIV_v6-v1/MINIAODSIM',
+#        'files_per_job'                      : 1,
+#        'total_files'                        : -1,
+#        'type'                               : 'BackgroundMC'
+#    },    
+#    'QCDmuEnrichedPt170to300' : {
+#        'datasetpath'                        : '/QCD_Pt-170to300_MuEnrichedPt5_TuneCUETP8M1_13TeV_pythia8/RunIISummer16MiniAODv2-PUMoriond17_backup_80X_mcRun2_asymptotic_2016_TrancheIV_v6-v1/MINIAODSIM',
+#        'files_per_job'                      : 1,
+#        'total_files'                        : -1,
+#        'type'                               : 'BackgroundMC'
+#    },
+#    'QCDmuEnrichedPt300to470' : {
+#        'datasetpath'                        : '/QCD_Pt-300to470_MuEnrichedPt5_TuneCUETP8M1_13TeV_pythia8/RunIISummer16MiniAODv2-PUMoriond17_80X_mcRun2_asymptotic_2016_TrancheIV_v6_ext2-v1/MINIAODSIM',
+#        'files_per_job'                      : 1,
+#        'total_files'                        : -1,
+#        'type'                               : 'BackgroundMC'
+#    },
+#    'QCDmuEnrichedPt470to600' : {
+#        'datasetpath'                        : '/QCD_Pt-470to600_MuEnrichedPt5_TuneCUETP8M1_13TeV_pythia8/RunIISummer16MiniAODv2-PUMoriond17_80X_mcRun2_asymptotic_2016_TrancheIV_v6_ext2-v1/MINIAODSIM',
+#        'files_per_job'                      : 1,
+#        'total_files'                        : -1,
+#        'type'                               : 'BackgroundMC'
+#    },
+#    'QCDmuEnrichedPt600to800' : {
+#        'datasetpath'                        : '/QCD_Pt-600to800_MuEnrichedPt5_TuneCUETP8M1_13TeV_pythia8/RunIISummer16MiniAODv2-PUMoriond17_80X_mcRun2_asymptotic_2016_TrancheIV_v6_ext1-v1/MINIAODSIM',
+#        'files_per_job'                      : 1,
+#        'total_files'                        : -1,
+#        'type'                               : 'BackgroundMC'
+#    },
+#    'QCDmuEnrichedPt800to1000' : {
+#        'datasetpath'                        : '/QCD_Pt-800to1000_MuEnrichedPt5_TuneCUETP8M1_13TeV_pythia8/RunIISummer16MiniAODv2-PUMoriond17_80X_mcRun2_asymptotic_2016_TrancheIV_v6_ext2-v1/MINIAODSIM',
+#        'files_per_job'                      : 1,
+#        'total_files'                        : -1,
+#        'type'                               : 'BackgroundMC'
+#    },
+#    'QCDmuEnrichedPtGt1000' : {
+#        'datasetpath'                        : '/QCD_Pt-1000toInf_MuEnrichedPt5_TuneCUETP8M1_13TeV_pythia8/RunIISummer16MiniAODv2-PUMoriond17_80X_mcRun2_asymptotic_2016_TrancheIV_v6_ext1-v3/MINIAODSIM',
+#        'files_per_job'                      : 1,
+#        'total_files'                        : -1,
+#        'type'                               : 'BackgroundMC'
+#    },
+    'WplusJets_madgraph' : {
+        'datasetpath'                        : '/WJetsToLNu_TuneCUETP8M1_13TeV-madgraphMLM-pythia8/PhaseIFall16MiniAOD-PhaseIFall16PUFlat20to50_PhaseIFall16_81X_upgrade2017_realistic_v26_ext1-v1/MINIAODSIM',
         'files_per_job'                      : 1,
         'total_files'                        : -1,
         'type'                               : 'BackgroundMC'
     },
-    'QCDmuEnrichedPt30to50' : {
-        'datasetpath'                        : '/QCD_Pt-30to50_MuEnrichedPt5_TuneCUETP8M1_13TeV_pythia8/RunIISummer16MiniAODv2-PUMoriond17_80X_mcRun2_asymptotic_2016_TrancheIV_v6-v1/MINIAODSIM',
-        'files_per_job'                      : 1,
-        'total_files'                        : -1,
-        'type'                               : 'BackgroundMC'
-    },
-    'QCDmuEnrichedPt50to80' : {
-        'datasetpath'                        : '/QCD_Pt-50to80_MuEnrichedPt5_TuneCUETP8M1_13TeV_pythia8/RunIISummer16MiniAODv2-PUMoriond17_80X_mcRun2_asymptotic_2016_TrancheIV_v6-v1/MINIAODSIM',
-        'files_per_job'                      : 1,
-        'total_files'                        : -1,
-        'type'                               : 'BackgroundMC'
-    },
-    'QCDmuEnrichedPt80to120' : {
-        'datasetpath'                        : '/QCD_Pt-80to120_MuEnrichedPt5_TuneCUETP8M1_13TeV_pythia8/RunIISummer16MiniAODv2-PUMoriond17_80X_mcRun2_asymptotic_2016_TrancheIV_v6-v1/MINIAODSIM',
-        'files_per_job'                      : 1,
-        'total_files'                        : -1,
-        'type'                               : 'BackgroundMC'
-    },
-    'QCDmuEnrichedPt120to170' : {
-        'datasetpath'                        : '/QCD_Pt-120to170_MuEnrichedPt5_TuneCUETP8M1_13TeV_pythia8/RunIISummer16MiniAODv2-PUMoriond17_80X_mcRun2_asymptotic_2016_TrancheIV_v6-v1/MINIAODSIM',
-        'files_per_job'                      : 1,
-        'total_files'                        : -1,
-        'type'                               : 'BackgroundMC'
-    },    
-    'QCDmuEnrichedPt170to300' : {
-        'datasetpath'                        : '/QCD_Pt-170to300_MuEnrichedPt5_TuneCUETP8M1_13TeV_pythia8/RunIISummer16MiniAODv2-PUMoriond17_backup_80X_mcRun2_asymptotic_2016_TrancheIV_v6-v1/MINIAODSIM',
-        'files_per_job'                      : 1,
-        'total_files'                        : -1,
-        'type'                               : 'BackgroundMC'
-    },
-    'QCDmuEnrichedPt300to470' : {
-        'datasetpath'                        : '/QCD_Pt-300to470_MuEnrichedPt5_TuneCUETP8M1_13TeV_pythia8/RunIISummer16MiniAODv2-PUMoriond17_80X_mcRun2_asymptotic_2016_TrancheIV_v6_ext2-v1/MINIAODSIM',
-        'files_per_job'                      : 1,
-        'total_files'                        : -1,
-        'type'                               : 'BackgroundMC'
-    },
-    'QCDmuEnrichedPt470to600' : {
-        'datasetpath'                        : '/QCD_Pt-470to600_MuEnrichedPt5_TuneCUETP8M1_13TeV_pythia8/RunIISummer16MiniAODv2-PUMoriond17_80X_mcRun2_asymptotic_2016_TrancheIV_v6_ext2-v1/MINIAODSIM',
-        'files_per_job'                      : 1,
-        'total_files'                        : -1,
-        'type'                               : 'BackgroundMC'
-    },
-    'QCDmuEnrichedPt600to800' : {
-        'datasetpath'                        : '/QCD_Pt-600to800_MuEnrichedPt5_TuneCUETP8M1_13TeV_pythia8/RunIISummer16MiniAODv2-PUMoriond17_80X_mcRun2_asymptotic_2016_TrancheIV_v6_ext1-v1/MINIAODSIM',
-        'files_per_job'                      : 1,
-        'total_files'                        : -1,
-        'type'                               : 'BackgroundMC'
-    },
-    'QCDmuEnrichedPt800to1000' : {
-        'datasetpath'                        : '/QCD_Pt-800to1000_MuEnrichedPt5_TuneCUETP8M1_13TeV_pythia8/RunIISummer16MiniAODv2-PUMoriond17_80X_mcRun2_asymptotic_2016_TrancheIV_v6_ext2-v1/MINIAODSIM',
-        'files_per_job'                      : 1,
-        'total_files'                        : -1,
-        'type'                               : 'BackgroundMC'
-    },
-    'QCDmuEnrichedPtGt1000' : {
-        'datasetpath'                        : '/QCD_Pt-1000toInf_MuEnrichedPt5_TuneCUETP8M1_13TeV_pythia8/RunIISummer16MiniAODv2-PUMoriond17_80X_mcRun2_asymptotic_2016_TrancheIV_v6_ext1-v3/MINIAODSIM',
-        'files_per_job'                      : 1,
-        'total_files'                        : -1,
-        'type'                               : 'BackgroundMC'
-    },
-    'WplusJets_mcatnlo' : {
-        'datasetpath'                        : '/WJetsToLNu_TuneCUETP8M1_13TeV-amcatnloFXFX-pythia8/RunIISummer16MiniAODv2-PUMoriond17_80X_mcRun2_asymptotic_2016_TrancheIV_v6-v1/MINIAODSIM',
-        'files_per_job'                      : 1,
-        'total_files'                        : -1,
-        'type'                               : 'BackgroundMC'
-    },
-    'QCDjetsFlatPt15to7000' : {
-        'datasetpath'                        : '/QCD_Pt-15to7000_TuneCUETP8M1_FlatP6_13TeV_pythia8/RunIISummer16MiniAODv2-PUMoriond17_80X_mcRun2_asymptotic_2016_TrancheIV_v6-v1/MINIAODSIM',
-        'files_per_job'                      : 1,
-        'total_files'                        : -1,
-        'type'                               : 'BackgroundMC'
-    },
+#    'QCDjetsFlatPt15to7000' : {
+#        'datasetpath'                        : '/QCD_Pt-15to7000_TuneCUETP8M1_FlatP6_13TeV_pythia8/RunIISummer16MiniAODv2-PUMoriond17_80X_mcRun2_asymptotic_2016_TrancheIV_v6-v1/MINIAODSIM',
+#        'files_per_job'                      : 1,
+#        'total_files'                        : -1,
+#        'type'                               : 'BackgroundMC'
+#    },
     'QCDjetsPt30to50' : {
-        'datasetpath'                        : '/QCD_Pt_30to50_TuneCUETP8M1_13TeV_pythia8/RunIISummer16MiniAODv2-PUMoriond17_80X_mcRun2_asymptotic_2016_TrancheIV_v6-v1/MINIAODSIM',
+        'datasetpath'                        : '/QCD_Pt_30to50_TuneCUETP8M1_13TeV_pythia8/PhaseIFall16MiniAOD-PhaseIFall16PUFlat20to50_PhaseIFall16_81X_upgrade2017_realistic_v26-v1/MINIAODSIM',
         'files_per_job'                      : 1,
         'total_files'                        : -1,
         'type'                               : 'BackgroundMC'
     },
     'QCDjetsPt50to80' : {
-        'datasetpath'                        : '/QCD_Pt_50to80_TuneCUETP8M1_13TeV_pythia8/RunIISummer16MiniAODv2-PUMoriond17_80X_mcRun2_asymptotic_2016_TrancheIV_v6-v1/MINIAODSIM',
+        'datasetpath'                        : '/QCD_Pt_50to80_TuneCUETP8M1_13TeV_pythia8/PhaseIFall16MiniAOD-PhaseIFall16PUFlat20to50_PhaseIFall16_81X_upgrade2017_realistic_v26-v1/MINIAODSIM',
         'files_per_job'                      : 1,
         'total_files'                        : -1,
         'type'                               : 'BackgroundMC'
     },
     'QCDjetsPt80to120' : {
-        'datasetpath'                        : '/QCD_Pt_80to120_TuneCUETP8M1_13TeV_pythia8/RunIISummer16MiniAODv2-PUMoriond17_80X_mcRun2_asymptotic_2016_TrancheIV_v6_ext2-v1/MINIAODSIM',
+        'datasetpath'                        : '/QCD_Pt_80to120_TuneCUETP8M1_13TeV_pythia8/PhaseIFall16MiniAOD-PhaseIFall16PUFlat20to50_PhaseIFall16_81X_upgrade2017_realistic_v26-v1/MINIAODSIM',
         'files_per_job'                      : 1,
         'total_files'                        : -1,
         'type'                               : 'BackgroundMC'
     },
     'QCDjetsPt120to170' : {
-        'datasetpath'                        : '/QCD_Pt_120to170_TuneCUETP8M1_13TeV_pythia8/RunIISummer16MiniAODv2-PUMoriond17_backup_80X_mcRun2_asymptotic_2016_TrancheIV_v6-v1/MINIAODSIM',
+        'datasetpath'                        : '/QCD_Pt_120to170_TuneCUETP8M1_13TeV_pythia8/PhaseIFall16MiniAOD-PhaseIFall16PUFlat20to50_PhaseIFall16_81X_upgrade2017_realistic_v26-v1/MINIAODSIM',
         'files_per_job'                      : 1,
         'total_files'                        : -1,
         'type'                               : 'BackgroundMC'
     },        
     'QCDjetsPt170to300' : {
-        'datasetpath'                        : '/QCD_Pt_170to300_TuneCUETP8M1_13TeV_pythia8/RunIISummer16MiniAODv2-PUMoriond17_80X_mcRun2_asymptotic_2016_TrancheIV_v6_ext1-v1/MINIAODSIM',
+        'datasetpath'                        : '/QCD_Pt_170to300_TuneCUETP8M1_13TeV_pythia8/PhaseIFall16MiniAOD-PhaseIFall16PUFlat20to50_PhaseIFall16_81X_upgrade2017_realistic_v26_ext1-v1/MINIAODSIM',
         'files_per_job'                      : 1,
         'total_files'                        : -1,
         'type'                               : 'BackgroundMC'
     },
     'QCDjetsPt300to470' : {
-        'datasetpath'                        : '/QCD_Pt_300to470_TuneCUETP8M1_13TeV_pythia8/RunIISummer16MiniAODv2-PUMoriond17_80X_mcRun2_asymptotic_2016_TrancheIV_v6_ext1-v1/MINIAODSIM',
+        'datasetpath'                        : '/QCD_Pt_300to470_TuneCUETP8M1_13TeV_pythia8/PhaseIFall16MiniAOD-PhaseIFall16PUFlat20to50_PhaseIFall16_81X_upgrade2017_realistic_v26_ext1-v1/MINIAODSIM',
         'files_per_job'                      : 1,
         'total_files'                        : -1,
         'type'                               : 'BackgroundMC'
     },
     'QCDjetsPt470to600' : {
-        'datasetpath'                        : '/QCD_Pt_470to600_TuneCUETP8M1_13TeV_pythia8/RunIISummer16MiniAODv2-PUMoriond17_backup_80X_mcRun2_asymptotic_2016_TrancheIV_v6-v1/MINIAODSIM',
+        'datasetpath'                        : '/QCD_Pt_470to600_TuneCUETP8M1_13TeV_pythia8/PhaseIFall16MiniAOD-PhaseIFall16PUFlat20to50_PhaseIFall16_81X_upgrade2017_realistic_v26_ext1-v1/MINIAODSIM',
         'files_per_job'                      : 1,
         'total_files'                        : -1,
         'type'                               : 'BackgroundMC'
     },
     'QCDjetsPt600to800' : {
-        'datasetpath'                        : '/QCD_Pt_600to800_TuneCUETP8M1_13TeV_pythia8/RunIISummer16MiniAODv2-PUMoriond17_backup_80X_mcRun2_asymptotic_2016_TrancheIV_v6-v1/MINIAODSIM',
+        'datasetpath'                        : '/QCD_Pt_600to800_TuneCUETP8M1_13TeV_pythia8/PhaseIFall16MiniAOD-PhaseIFall16PUFlat20to50_PhaseIFall16_81X_upgrade2017_realistic_v26_ext1-v1/MINIAODSIM',
         'files_per_job'                      : 1,
         'total_files'                        : -1,
         'type'                               : 'BackgroundMC'
     },
     'QCDjetsPt800to1000' : {
-        'datasetpath'                        : '/QCD_Pt_800to1000_TuneCUETP8M1_13TeV_pythia8/RunIISummer16MiniAODv2-PUMoriond17_80X_mcRun2_asymptotic_2016_TrancheIV_v6_ext1-v1/MINIAODSIM',
+        'datasetpath'                        : '/QCD_Pt_800to1000_TuneCUETP8M1_13TeV_pythia8/PhaseIFall16MiniAOD-PhaseIFall16PUFlat20to50_PhaseIFall16_81X_upgrade2017_realistic_v26_ext1-v1/MINIAODSIM',
         'files_per_job'                      : 1,
         'total_files'                        : -1,
         'type'                               : 'BackgroundMC'
     },
     'QCDjetsPt1000to1400' : {
-        'datasetpath'                        : '/QCD_Pt_1000to1400_TuneCUETP8M1_13TeV_pythia8/RunIISummer16MiniAODv2-PUMoriond17_80X_mcRun2_asymptotic_2016_TrancheIV_v6_ext1-v1/MINIAODSIM',
+        'datasetpath'                        : '/QCD_Pt_1000to1400_TuneCUETP8M1_13TeV_pythia8/PhaseIFall16MiniAOD-PhaseIFall16PUFlat20to50_PhaseIFall16_81X_upgrade2017_realistic_v26_ext1-v1/MINIAODSIM',
         'files_per_job'                      : 1,
         'total_files'                        : -1,
         'type'                               : 'BackgroundMC'
     },
     'QCDjetsPt1400to1800' : {
-        'datasetpath'                        : '/QCD_Pt_1400to1800_TuneCUETP8M1_13TeV_pythia8/RunIISummer16MiniAODv2-PUMoriond17_80X_mcRun2_asymptotic_2016_TrancheIV_v6_ext1-v1/MINIAODSIM',
+        'datasetpath'                        : '/QCD_Pt_1400to1800_TuneCUETP8M1_13TeV_pythia8/PhaseIFall16MiniAOD-PhaseIFall16PUFlat20to50_PhaseIFall16_81X_upgrade2017_realistic_v26-v1/MINIAODSIM',
         'files_per_job'                      : 1,
         'total_files'                        : -1,
         'type'                               : 'BackgroundMC'
     },
-    'QCDjetsPt1800to2400' : {
-        'datasetpath'                        : '/QCD_Pt_1800to2400_TuneCUETP8M1_13TeV_pythia8/RunIISummer16MiniAODv2-PUMoriond17_80X_mcRun2_asymptotic_2016_TrancheIV_v6_ext1-v1/MINIAODSIM',
-        'files_per_job'                      : 1,  
-        'total_files'                        : -1,
-        'type'                               : 'BackgroundMC'
-    },
+#    'QCDjetsPt1800to2400' : {
+#        'datasetpath'                        : '/QCD_Pt_1800to2400_TuneCUETP8M1_13TeV_pythia8/RunIISummer16MiniAODv2-PUMoriond17_80X_mcRun2_asymptotic_2016_TrancheIV_v6_ext1-v1/MINIAODSIM',
+#        'files_per_job'                      : 1,  
+#        'total_files'                        : -1,
+#        'type'                               : 'BackgroundMC'
+#    },
     'QCDjetsPt2400to3200' : {
-        'datasetpath'                        : '/QCD_Pt_2400to3200_TuneCUETP8M1_13TeV_pythia8/RunIISummer16MiniAODv2-PUMoriond17_80X_mcRun2_asymptotic_2016_TrancheIV_v6_ext1-v1/MINIAODSIM',
+        'datasetpath'                        : '/QCD_Pt_2400to3200_TuneCUETP8M1_13TeV_pythia8/PhaseIFall16MiniAOD-PhaseIFall16PUFlat20to50_PhaseIFall16_81X_upgrade2017_realistic_v26-v1/MINIAODSIM',
         'files_per_job'                      : 1,
         'total_files'                        : -1,
         'type'                               : 'BackgroundMC'
     },
     'QCDjetsPtGt3200' : {
-        'datasetpath'                        : '/QCD_Pt_3200toInf_TuneCUETP8M1_13TeV_pythia8/RunIISummer16MiniAODv2-PUMoriond17_80X_mcRun2_asymptotic_2016_TrancheIV_v6-v3/MINIAODSIM',
+        'datasetpath'                        : '/QCD_Pt_3200toInf_TuneCUETP8M1_13TeV_pythia8/PhaseIFall16MiniAOD-PhaseIFall16PUFlat20to50_PhaseIFall16_81X_upgrade2017_realistic_v26-v1/MINIAODSIM',
         'files_per_job'                      : 1,
         'total_files'                        : -1,
         'type'                               : 'BackgroundMC'
     },
-    'QCDEmEnrichedPt20to30' : {
-        'datasetpath'                        : '/QCD_Pt-20to30_EMEnriched_TuneCUETP8M1_13TeV_pythia8/RunIISummer16MiniAODv2-PUMoriond17_80X_mcRun2_asymptotic_2016_TrancheIV_v6-v1/MINIAODSIM',
-        'files_per_job'                      : 1,
-        'total_files'                        : -1,
-        'type'                               : 'BackgroundMC'
-    },
-    'QCDEmEnrichedPt30to50' : {
-        'datasetpath'                        : '/QCD_Pt-30to50_EMEnriched_TuneCUETP8M1_13TeV_pythia8/RunIISummer16MiniAODv2-PUMoriond17_80X_mcRun2_asymptotic_2016_TrancheIV_v6_ext1-v1/MINIAODSIM',
-        'files_per_job'                      : 1,
-        'total_files'                        : -1,
-        'type'                               : 'BackgroundMC'
-    },
-    'QCDEmEnrichedPt50to80' : {
-        'datasetpath'                        : '/QCD_Pt-50to80_EMEnriched_TuneCUETP8M1_13TeV_pythia8/RunIISummer16MiniAODv2-PUMoriond17_80X_mcRun2_asymptotic_2016_TrancheIV_v6_ext1-v1/MINIAODSIM',
-        'files_per_job'                      : 1,
-        'total_files'                        : -1,
-        'type'                               : 'BackgroundMC'
-    },
-    'QCDEmEnrichedPt80to120' : {
-        'datasetpath'                        : '/QCD_Pt-80to120_EMEnriched_TuneCUETP8M1_13TeV_pythia8/RunIISummer16MiniAODv2-PUMoriond17_80X_mcRun2_asymptotic_2016_TrancheIV_v6_ext1-v1/MINIAODSIM',
-        'files_per_job'                      : 1,
-        'total_files'                        : -1,
-        'type'                               : 'BackgroundMC'
-    },
-    'QCDEmEnrichedPt120to170' : {
-        'datasetpath'                        : '/QCD_Pt-120to170_EMEnriched_TuneCUETP8M1_13TeV_pythia8/RunIISummer16MiniAODv2-PUMoriond17_80X_mcRun2_asymptotic_2016_TrancheIV_v6_ext1-v1/MINIAODSIM',
-        'files_per_job'                      : 1,
-        'total_files'                        : -1,
-        'type'                               : 'BackgroundMC'
-    },
-    'QCDEmEnrichedPt170to300' : {
-        'datasetpath'                        : '/QCD_Pt-170to300_EMEnriched_TuneCUETP8M1_13TeV_pythia8/RunIISummer16MiniAODv2-PUMoriond17_80X_mcRun2_asymptotic_2016_TrancheIV_v6-v1/MINIAODSIM',
-        'files_per_job'                      : 1,
-        'total_files'                        : -1,
-        'type'                               : 'BackgroundMC'
-    },
-    'QCDEmEnrichedPtGt300' : {
-        'datasetpath'                        : '/QCD_Pt-300toInf_EMEnriched_TuneCUETP8M1_13TeV_pythia8/RunIISummer16MiniAODv2-PUMoriond17_80X_mcRun2_asymptotic_2016_TrancheIV_v6-v1/MINIAODSIM',
-        'files_per_job'                      : 1,
-        'total_files'                        : -1,
-        'type'                               : 'BackgroundMC'
-    },
+#    'QCDEmEnrichedPt20to30' : {
+#        'datasetpath'                        : '/QCD_Pt-20to30_EMEnriched_TuneCUETP8M1_13TeV_pythia8/RunIISummer16MiniAODv2-PUMoriond17_80X_mcRun2_asymptotic_2016_TrancheIV_v6-v1/MINIAODSIM',
+#        'files_per_job'                      : 1,
+#        'total_files'                        : -1,
+#        'type'                               : 'BackgroundMC'
+#    },
+#    'QCDEmEnrichedPt30to50' : {
+#        'datasetpath'                        : '/QCD_Pt-30to50_EMEnriched_TuneCUETP8M1_13TeV_pythia8/RunIISummer16MiniAODv2-PUMoriond17_80X_mcRun2_asymptotic_2016_TrancheIV_v6_ext1-v1/MINIAODSIM',
+#        'files_per_job'                      : 1,
+#        'total_files'                        : -1,
+#        'type'                               : 'BackgroundMC'
+#    },
+#    'QCDEmEnrichedPt50to80' : {
+#        'datasetpath'                        : '/QCD_Pt-50to80_EMEnriched_TuneCUETP8M1_13TeV_pythia8/RunIISummer16MiniAODv2-PUMoriond17_80X_mcRun2_asymptotic_2016_TrancheIV_v6_ext1-v1/MINIAODSIM',
+#        'files_per_job'                      : 1,
+#        'total_files'                        : -1,
+#        'type'                               : 'BackgroundMC'
+#    },
+#    'QCDEmEnrichedPt80to120' : {
+#        'datasetpath'                        : '/QCD_Pt-80to120_EMEnriched_TuneCUETP8M1_13TeV_pythia8/RunIISummer16MiniAODv2-PUMoriond17_80X_mcRun2_asymptotic_2016_TrancheIV_v6_ext1-v1/MINIAODSIM',
+#        'files_per_job'                      : 1,
+#        'total_files'                        : -1,
+#        'type'                               : 'BackgroundMC'
+#    },
+#    'QCDEmEnrichedPt120to170' : {
+#        'datasetpath'                        : '/QCD_Pt-120to170_EMEnriched_TuneCUETP8M1_13TeV_pythia8/RunIISummer16MiniAODv2-PUMoriond17_80X_mcRun2_asymptotic_2016_TrancheIV_v6_ext1-v1/MINIAODSIM',
+#        'files_per_job'                      : 1,
+#        'total_files'                        : -1,
+#        'type'                               : 'BackgroundMC'
+#    },
+#    'QCDEmEnrichedPt170to300' : {
+#        'datasetpath'                        : '/QCD_Pt-170to300_EMEnriched_TuneCUETP8M1_13TeV_pythia8/RunIISummer16MiniAODv2-PUMoriond17_80X_mcRun2_asymptotic_2016_TrancheIV_v6-v1/MINIAODSIM',
+#        'files_per_job'                      : 1,
+#        'total_files'                        : -1,
+#        'type'                               : 'BackgroundMC'
+#    },
+#    'QCDEmEnrichedPtGt300' : {
+#        'datasetpath'                        : '/QCD_Pt-300toInf_EMEnriched_TuneCUETP8M1_13TeV_pythia8/RunIISummer16MiniAODv2-PUMoriond17_80X_mcRun2_asymptotic_2016_TrancheIV_v6-v1/MINIAODSIM',
+#        'files_per_job'                      : 1,
+#        'total_files'                        : -1,
+#        'type'                               : 'BackgroundMC'
+#    },
 
 
 }
-smHiggsMassPoints = [ 120, 125, 130 ]
-for massPoint in smHiggsMassPoints:
-    #ggSampleName = "ggHiggs%1.0ftoTauTau" % massPoint
-    #samples[ggSampleName] = {
-    #    'datasetpath'                        : '/GluGluHToTauTau_M%1.0f_13TeV_powheg_pythia8/RunIISpring15DR74-Asympt25ns_MCRUN2_74_V9-v1/AODSIM' % massPoint,
-    #    'files_per_job'                      : 1,
-    #    'total_files'                        : -1,
-    #    'type'                               : 'SignalMC'
-    #}
-    #vbfSampleName = "vbfHiggs%1.0ftoTauTau" % massPoint
-    #samples[vbfSampleName] = {
-    #    'datasetpath'                        : '/VBFHToTauTau_M%1.0f_13TeV_powheg_pythia8/RunIISpring15DR74-Asympt25ns_MCRUN2_74_V9-v1/AODSIM' % massPoint,
-    #    'files_per_job'                      : 1,
-    #    'total_files'                        : -1,
-    #    'type'                               : 'SignalMC'
-    #}
-    wPlusHSampleName = "WplusHHiggs%1.0ftoTauTau" % massPoint
-    samples[wPlusHSampleName] = {
-        'datasetpath'                        : '/WplusHToTauTau_M%1.0f_13TeV_powheg_pythia8/RunIISummer16MiniAODv2-PUMoriond17_80X_mcRun2_asymptotic_2016_TrancheIV_v6-v1/MINIAODSIM' % massPoint,
-        'files_per_job'                      : 1,
-        'total_files'                        : -1,
-        'type'                               : 'SignalMC'
-    }
-    wMinusHSampleName = "WminusHHiggs%1.0ftoTauTau" % massPoint
-    samples[wMinusHSampleName] = {
-        'datasetpath'                        : '/WminusHToTauTau_M%1.0f_13TeV_powheg_pythia8/RunIISummer16MiniAODv2-PUMoriond17_80X_mcRun2_asymptotic_2016_TrancheIV_v6-v1/MINIAODSIM' % massPoint,
-        'files_per_job'                      : 1,
-        'total_files'                        : -1,
-        'type'                               : 'SignalMC'
-    }
-    zHSampleName = "ZHHiggs%1.0ftoTauTau" % massPoint
-    samples[zHSampleName] = {
-        'datasetpath'                        : '/ZHToTauTau_M%1.0f_13TeV_powheg_pythia8/RunIISummer16MiniAODv2-PUMoriond17_80X_mcRun2_asymptotic_2016_TrancheIV_v6-v1/MINIAODSIM' % massPoint,
-        'files_per_job'                      : 1,
-        'total_files'                        : -1,
-        'type'                               : 'SignalMC'
-    }
-smHiggsMassPoints2 = [ 120, 130 ]
-for massPoint in smHiggsMassPoints2:
-	tthSampleName = "tthHiggs%1.0ftoTauTau" % massPoint
-	samples[tthSampleName] = {
-	    'datasetpath'                            : '/ttHJetToTT_M%1.0f_13TeV_amcatnloFXFX_madspin_pythia8/RunIISummer16MiniAODv2-PUMoriond17_80X_mcRun2_asymptotic_2016_TrancheIV_v6-v1/MINIAODSIM' % massPoint,
-	    'files_per_job'                          : 1,
-	    'total_files'                            : -1,
-	    'type'                                   : 'SignalMC'
-	}
-tthSampleName = "tthHiggs125toTauTau"
-samples[tthSampleName] = {
-    'datasetpath'                            : '/ttHJetToTT_M125_13TeV_amcatnloFXFX_madspin_pythia8/RunIISummer16MiniAODv2-PUMoriond17_80X_mcRun2_asymptotic_2016_TrancheIV_v6_ext4-v1/MINIAODSIM',
-    'files_per_job'                          : 1,
-    'total_files'                            : -1,
-    'type'                                   : 'SignalMC'
-}
-ggSampleName = "ggHiggs125toTauTau"
-samples[ggSampleName] = {
-    'datasetpath'                        : '/GluGluHToTauTau_M125_13TeV_powheg_pythia8/RunIISummer16MiniAODv2-PUMoriond17_80X_mcRun2_asymptotic_2016_TrancheIV_v6-v1/MINIAODSIM',
-    'files_per_job'                      : 1,
-    'total_files'                        : -1,
-    'type'                               : 'SignalMC'
-}
-ggSampleName = "ggHiggs130toTauTau"
-samples[ggSampleName] = {
-    'datasetpath'                        : '/GluGluHToTauTau_M130_13TeV_powheg_pythia8/RunIISummer16MiniAODv2-PUMoriond17_80X_mcRun2_asymptotic_2016_TrancheIV_v6_ext1-v1/MINIAODSIM',
-    'files_per_job'                      : 1,
-    'total_files'                        : -1,
-    'type'                               : 'SignalMC'
-}
-vbfSampleName = "vbfHiggs125toTauTau"
-samples[vbfSampleName] = {
-    'datasetpath'                        : '/VBFHToTauTau_M125_13TeV_powheg_pythia8/RunIISummer16MiniAODv2-PUMoriond17_80X_mcRun2_asymptotic_2016_TrancheIV_v6-v1/MINIAODSIM',
-    'files_per_job'                      : 1,
-    'total_files'                        : -1,
-    'type'                               : 'SignalMC'
-}
-# currently 29 mass points available
-mssmHiggsMassPoints1 = [ 80, 90, 100, 110, 120, 130, 160, 180, 200, 250, 300, 350, 400, 450, 500, 600, 700, 800, 1000, 1200, 1400, 1500, 1600, 1800, 2000, 2300, 2600, 2900, 3200 ]
+#smHiggsMassPoints = [ 120, 125, 130 ]
+#for massPoint in smHiggsMassPoints:
+#    #ggSampleName = "ggHiggs%1.0ftoTauTau" % massPoint
+#    #samples[ggSampleName] = {
+#    #    'datasetpath'                        : '/GluGluHToTauTau_M%1.0f_13TeV_powheg_pythia8/RunIISpring15DR74-Asympt25ns_MCRUN2_74_V9-v1/AODSIM' % massPoint,
+#    #    'files_per_job'                      : 1,
+#    #    'total_files'                        : -1,
+#    #    'type'                               : 'SignalMC'
+#    #}
+#    #vbfSampleName = "vbfHiggs%1.0ftoTauTau" % massPoint
+#    #samples[vbfSampleName] = {
+#    #    'datasetpath'                        : '/VBFHToTauTau_M%1.0f_13TeV_powheg_pythia8/RunIISpring15DR74-Asympt25ns_MCRUN2_74_V9-v1/AODSIM' % massPoint,
+#    #    'files_per_job'                      : 1,
+#    #    'total_files'                        : -1,
+#    #    'type'                               : 'SignalMC'
+#    #}
+#    wPlusHSampleName = "WplusHHiggs%1.0ftoTauTau" % massPoint
+#    samples[wPlusHSampleName] = {
+#        'datasetpath'                        : '/WplusHToTauTau_M%1.0f_13TeV_powheg_pythia8/RunIISummer16MiniAODv2-PUMoriond17_80X_mcRun2_asymptotic_2016_TrancheIV_v6-v1/MINIAODSIM' % massPoint,
+#        'files_per_job'                      : 1,
+#        'total_files'                        : -1,
+#        'type'                               : 'SignalMC'
+#    }
+#    wMinusHSampleName = "WminusHHiggs%1.0ftoTauTau" % massPoint
+#    samples[wMinusHSampleName] = {
+#        'datasetpath'                        : '/WminusHToTauTau_M%1.0f_13TeV_powheg_pythia8/RunIISummer16MiniAODv2-PUMoriond17_80X_mcRun2_asymptotic_2016_TrancheIV_v6-v1/MINIAODSIM' % massPoint,
+#        'files_per_job'                      : 1,
+#        'total_files'                        : -1,
+#        'type'                               : 'SignalMC'
+#    }
+#    zHSampleName = "ZHHiggs%1.0ftoTauTau" % massPoint
+#    samples[zHSampleName] = {
+#        'datasetpath'                        : '/ZHToTauTau_M%1.0f_13TeV_powheg_pythia8/RunIISummer16MiniAODv2-PUMoriond17_80X_mcRun2_asymptotic_2016_TrancheIV_v6-v1/MINIAODSIM' % massPoint,
+#        'files_per_job'                      : 1,
+#        'total_files'                        : -1,
+#        'type'                               : 'SignalMC'
+#    }
+#smHiggsMassPoints2 = [ 120, 130 ]
+#for massPoint in smHiggsMassPoints2:
+#	tthSampleName = "tthHiggs%1.0ftoTauTau" % massPoint
+#	samples[tthSampleName] = {
+#	    'datasetpath'                            : '/ttHJetToTT_M%1.0f_13TeV_amcatnloFXFX_madspin_pythia8/RunIISummer16MiniAODv2-PUMoriond17_80X_mcRun2_asymptotic_2016_TrancheIV_v6-v1/MINIAODSIM' % massPoint,
+#	    'files_per_job'                          : 1,
+#	    'total_files'                            : -1,
+#	    'type'                                   : 'SignalMC'
+#	}
+#tthSampleName = "tthHiggs125toTauTau"
+#samples[tthSampleName] = {
+#    'datasetpath'                            : '/ttHJetToTT_M125_13TeV_amcatnloFXFX_madspin_pythia8/RunIISummer16MiniAODv2-PUMoriond17_80X_mcRun2_asymptotic_2016_TrancheIV_v6_ext4-v1/MINIAODSIM',
+#    'files_per_job'                          : 1,
+#    'total_files'                            : -1,
+#    'type'                                   : 'SignalMC'
+#}
+#ggSampleName = "ggHiggs125toTauTau"
+#samples[ggSampleName] = {
+#    'datasetpath'                        : '/GluGluHToTauTau_M125_13TeV_powheg_pythia8/RunIISummer16MiniAODv2-PUMoriond17_80X_mcRun2_asymptotic_2016_TrancheIV_v6-v1/MINIAODSIM',
+#    'files_per_job'                      : 1,
+#    'total_files'                        : -1,
+#    'type'                               : 'SignalMC'
+#}
+#ggSampleName = "ggHiggs130toTauTau"
+#samples[ggSampleName] = {
+#    'datasetpath'                        : '/GluGluHToTauTau_M130_13TeV_powheg_pythia8/RunIISummer16MiniAODv2-PUMoriond17_80X_mcRun2_asymptotic_2016_TrancheIV_v6_ext1-v1/MINIAODSIM',
+#    'files_per_job'                      : 1,
+#    'total_files'                        : -1,
+#    'type'                               : 'SignalMC'
+#}
+#vbfSampleName = "vbfHiggs125toTauTau"
+#samples[vbfSampleName] = {
+#    'datasetpath'                        : '/VBFHToTauTau_M125_13TeV_powheg_pythia8/RunIISummer16MiniAODv2-PUMoriond17_80X_mcRun2_asymptotic_2016_TrancheIV_v6-v1/MINIAODSIM',
+#    'files_per_job'                      : 1,
+#    'total_files'                        : -1,
+#    'type'                               : 'SignalMC'
+#}
+# currently 23 mass points available
+mssmHiggsMassPoints1 = [ 140, 180, 200, 250, 300, 350, 400, 450, 500, 600, 700, 800, 900, 1000, 1200, 1400, 1600, 2000, 2300, 2600, 2900 ]
 for massPoint in mssmHiggsMassPoints1:
     ggSampleName = "ggA%1.0ftoTauTau" % massPoint
     samples[ggSampleName] = {
-        'datasetpath'                        : '/SUSYGluGluToHToTauTau_M-%1.0f_TuneCUETP8M1_13TeV-pythia8/RunIISummer16MiniAODv2-PUMoriond17_80X_mcRun2_asymptotic_2016_TrancheIV_v6-v1/MINIAODSIM' % massPoint,
+        'datasetpath'                        : '/SUSYGluGluToHToTauTau_M-%1.0f_TuneCUETP8M1_13TeV-pythia8/PhaseIFall16MiniAOD-PhaseIFall16PUFlat20to50_PhaseIFall16_81X_upgrade2017_realistic_v26-v1/MINIAODSIM' % massPoint,
         'files_per_job'                      : 1,
         'total_files'                        : -1, 
         'type'                               : 'SignalMC'
     }
 
-# currently 31 mass points available
-mssmHiggsMassPoints2 = [ 80, 90, 100, 110, 120, 130, 140, 160, 180, 200, 250, 350, 400, 450, 500, 600, 700, 800, 900, 1000, 1200, 1400, 1500, 1600, 1800, 2000, 2300, 2600, 2900, 3200 ]
+mssmHiggsMassPoints2 = [ 160, 1800 ]
 for massPoint in mssmHiggsMassPoints2:
-    bbSampleName = "bbA%1.0ftoTauTau" % massPoint
-    samples[bbSampleName] = {
-        'datasetpath'                        : '/SUSYGluGluToBBHToTauTau_M-%1.0f_TuneCUETP8M1_13TeV-pythia8/RunIISummer16MiniAODv2-PUMoriond17_80X_mcRun2_asymptotic_2016_TrancheIV_v6-v1/MINIAODSIM' % massPoint,
+    ggSampleName = "ggA%1.0ftoTauTau" % massPoint
+    samples[ggSampleName] = {
+        'datasetpath'                        : '/SUSYGluGluToHToTauTau_M-%1.0f_TuneCUETP8M1_13TeV-pythia8/PhaseIFall16MiniAOD-PhaseIFall16PUFlat20to50_PhaseIFall16_81X_upgrade2017_realistic_v26-v2/MINIAODSIM' % massPoint,
         'files_per_job'                      : 1,
         'total_files'                        : -1, 
         'type'                               : 'SignalMC'
     }
-# v1 of the mass point 300 is invalid
-bbSampleName = "bbA300toTauTau"
+
+# currently 23 mass points available
+mssmHiggsMassPoints3 = [ 140, 160, 180, 200, 300, 350, 400, 450, 500, 600, 700, 800, 900, 1000, 1200, 1400, 1600, 1800, 2000, 2300, 2600, 3200 ]
+for massPoint in mssmHiggsMassPoints3:
+    bbSampleName = "bbA%1.0ftoTauTau" % massPoint
+    samples[bbSampleName] = {
+        'datasetpath'                        : '/SUSYGluGluToBBHToTauTau_M-%1.0f_TuneCUETP8M1_13TeV-pythia8/PhaseIFall16MiniAOD-PhaseIFall16PUFlat20to50_PhaseIFall16_81X_upgrade2017_realistic_v26-v1/MINIAODSIM' % massPoint,
+        'files_per_job'                      : 1,
+        'total_files'                        : -1, 
+        'type'                               : 'SignalMC'
+    }
+
+bbSampleName = "bbA250toTauTau"
 samples[bbSampleName] = {
-    'datasetpath'                        : '/SUSYGluGluToBBHToTauTau_M-300_TuneCUETP8M1_13TeV-pythia8/RunIISummer16MiniAODv2-PUMoriond17_80X_mcRun2_asymptotic_2016_TrancheIV_v6-v2/MINIAODSIM',
+    'datasetpath'                        : '/SUSYGluGluToBBHToTauTau_M-250_TuneCUETP8M1_13TeV-pythia8/PhaseIFall16MiniAOD-PhaseIFall16PUFlat20to50_PhaseIFall16_81X_upgrade2017_realistic_v26-v2/MINIAODSIM',
     'files_per_job'                      : 1,
     'total_files'                        : -1, 
     'type'                               : 'SignalMC'
 }
 
-# currently 11 mass points available
-ZprimeMassPoints = [ 500, 750, 1000, 1250, 1500, 1750, 2000, 2500, 3000, 3500, 4000 ]
+# currently 9 mass points available
+ZprimeMassPoints = [ 750, 1000, 1250, 1750, 2000, 2500, 3000, 3500, 4000 ]
 for massPoint in ZprimeMassPoints:
     sampleName = "Zprime%1.0ftoTauTau" % massPoint
     samples[sampleName] = {
@@ -343,16 +353,16 @@ for massPoint in ZprimeMassPoints:
         'type'                               : 'SignalMC'
     }
 
-# currently 27 mass points available
-WprimeMassPoints = [ 400, 600, 1000, 1200, 1400, 1600, 1800, 2000, 2200, 2400, 2600, 2800, 3000, 3200, 3400, 3600, 3800, 4000, 4200, 4400, 4600, 4800, 5000, 5200, 5400, 5600, 5800 ]
-for massPoint in WprimeMassPoints:
-    sampleName = "Wprime%1.0ftoTauNu" % massPoint
-    samples[sampleName] = {
-        'datasetpath'                        : '/WprimeToTauNu_M-%1.0f_TuneCUETP8M1_13TeV-pythia8-tauola/RunIISummer16MiniAODv2-PUMoriond17_80X_mcRun2_asymptotic_2016_TrancheIV_v6-v1/MINIAODSIM' % massPoint,
-        'files_per_job'                      : 1,
-        'total_files'                        : -1,
-        'type'                               : 'SignalMC'
-    }
+## currently 27 mass points available
+#WprimeMassPoints = [ 400, 600, 1000, 1200, 1400, 1600, 1800, 2000, 2200, 2400, 2600, 2800, 3000, 3200, 3400, 3600, 3800, 4000, 4200, 4400, 4600, 4800, 5000, 5200, 5400, 5600, 5800 ]
+#for massPoint in WprimeMassPoints:
+#    sampleName = "Wprime%1.0ftoTauNu" % massPoint
+#    samples[sampleName] = {
+#        'datasetpath'                        : '/WprimeToTauNu_M-%1.0f_TuneCUETP8M1_13TeV-pythia8-tauola/RunIISummer16MiniAODv2-PUMoriond17_80X_mcRun2_asymptotic_2016_TrancheIV_v6-v1/MINIAODSIM' % massPoint,
+#        'files_per_job'                      : 1,
+#        'total_files'                        : -1,
+#        'type'                               : 'SignalMC'
+#    }
 
 version = "tauId_v1"
 
@@ -379,7 +389,7 @@ config.Data.inputDBS = 'global'
 config.Data.splitting = 'FileBased'
 config.Data.unitsPerJob = $files_per_job
 config.Data.totalUnits = $total_files
-config.Data.outLFNDirBase = '/store/user/anehrkor/TauIDMVATraining2016/Summer16_25ns_V1/'
+config.Data.outLFNDirBase = '/store/user/anehrkor/TauIDMVATraining2017/PhaseIFall16_81X_upgrade2017_realistic/'
 config.Data.publication = False
 
 config.section_("Site")
@@ -406,7 +416,7 @@ config.Data.unitsPerJob = $lumis_per_job
 config.Data.totalUnits = $total_lumis
 config.Data.lumiMask = 'https://cms-service-dqm.web.cern.ch/cms-service-dqm/CAF/certification/Collisions12/8TeV/Prompt/Cert_190456-208686_8TeV_PromptReco_Collisions12_JSON.txt'
 #config.Data.runRange = '193093-193999' # '193093-194075'
-config.Data.outLFNDirBase = '/store/user/anehrkor/TauIDMVATraining2016/Summer16_25ns_V1/'
+config.Data.outLFNDirBase = '/store/user/anehrkor/TauIDMVATraining2017/PhaseIFall16_81X_upgrade2017_realistic/'
 config.Data.publication = False                                                                                                                                                  
 
 config.section_("Site")


### PR DESCRIPTION
Dear all,

this PR includes the following changes:
- adaptations to cope with the TMVA interface changes of the ROOT version used in CMSSW 9 (this will lead to the master not working with CMSSW versions below 9!)
- added possibility to place various pt cuts on the candidates used to calculate recTauNphotons such that trainings with different pt cuts can be done without having to produce new ntuples for every cut
- added the tau Id trained with Summer16 samples to the ntuples for ROC curve comparison when doing new trainings

I would like to note that there are also some changes to the samples in the various scripts from when I performed the first studies with this year's scenario. These will have to be changed anyhow though once the next training is started with the new MC campaign, and don't have any impact on the functionality of the package.

Best,
Alex